### PR TITLE
Add body size limits to mitigate body-parser vulnerability

### DIFF
--- a/workspaces/apps/shop-mvc-express/src/app.ts
+++ b/workspaces/apps/shop-mvc-express/src/app.ts
@@ -8,8 +8,8 @@ import { createAppRouter } from './routes';
 export function createApp() {
   const app = express();
 
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: false })); // Parse HTML form data
+  app.use(express.json({ limit: config.requestLimits.body }));
+  app.use(express.urlencoded({ extended: false, limit: config.requestLimits.body })); // Parse HTML form data
 
   // TODO: Implement later: review existing ones and add other Helmet defaults (noSniff, frameguard, hidePoweredBy, etc.)
   // Security headers via Helmet

--- a/workspaces/apps/shop-mvc-express/src/config.ts
+++ b/workspaces/apps/shop-mvc-express/src/config.ts
@@ -34,5 +34,8 @@ export const config = {
   deploymentEnv,
   nodeEnv: env.NODE_ENV,
   port: env.PORT,
+  requestLimits: {
+    body: env.BODY_PARSER_LIMIT,
+  },
   services: serviceUrlsByEnv[deploymentEnv],
 } as const;

--- a/workspaces/apps/shop-mvc-express/src/env.ts
+++ b/workspaces/apps/shop-mvc-express/src/env.ts
@@ -1,6 +1,15 @@
 import { baseSchema, defineEnv } from '@workspaces/packages/config';
 import dotenv from 'dotenv';
+import { z } from 'zod';
 
 dotenv.config();
 
-export const env = defineEnv(baseSchema);
+const schema = baseSchema.extend({
+  BODY_PARSER_LIMIT: z
+    .string()
+    .trim()
+    .default('1mb')
+    .describe('Maximum size of incoming JSON/urlencoded bodies (supports byte notation)'),
+});
+
+export const env = defineEnv(schema);


### PR DESCRIPTION
## Summary
- add a configurable BODY_PARSER_LIMIT env value for shop-mvc-express
- apply the configured size limit to JSON and urlencoded body parsing to mitigate the body-parser vulnerability exposure

## Testing
- pnpm --filter shop-mvc-express typecheck


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448ec8235c832598f7e10b0bd62b30)