### PR TITLE
Docs: update agent guidance and repo overview

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -91,8 +91,10 @@ Use official product docs as the source of truth for tool-specific file
 locations and behavior:
 
 - Agent Skills open standard: <https://agentskills.io/specification>
-- Agent Skills best practices: <https://agentskills.io/skill-creation/best-practices>
+- Agent Skills best practices (open spec): <https://agentskills.io/skill-creation/best-practices>
 - Claude Code: <https://code.claude.com/docs>
+- Claude Code subagents: <https://code.claude.com/docs/en/sub-agents>
+- Claude Skill authoring best practices (vendor): <https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices>
 - OpenAI Codex: <https://developers.openai.com/codex>
 - Cursor: <https://cursor.com/docs>
 - AGENTS.md standard: <https://agents.md>

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -64,10 +64,9 @@ When adding or renaming a skill, keep the folder name equal to the frontmatter
 `name`, update this index, and add or update any required tool-specific thin
 adapters such as `.claude/skills/<name>/SKILL.md`.
 
-Hooks and MCP guidance live in [skills/designing-hooks/](./skills/designing-hooks/)
-and [skills/configuring-mcp/](./skills/configuring-mcp/). Create
-`.agents/hooks/` or `.agents/mcp/` only when there are concrete reusable
-scripts, configs, or adapter files to store.
+Hooks and MCP guidance belong in [skills/designing-hooks/](./skills/designing-hooks/)
+and [skills/configuring-mcp/](./skills/configuring-mcp/). Create `.agents/hooks/`
+only when concrete reusable hook scripts or adapters need a portable home.
 
 ## Tool Adapter Map
 

--- a/.agents/agents/update-docs.md
+++ b/.agents/agents/update-docs.md
@@ -13,7 +13,7 @@ Document real behavior, workflows, APIs, migrations, and decisions with concise,
 
 ## Pairs With
 
-- [update-docs skill](../skills/update-docs/SKILL.md) — canonical workflow, including the Freshness Window for AI-agent docs.
+- [update-docs skill](../skills/update-docs/SKILL.md) — canonical workflow, including the `Freshness Window`, `AI-Agent Docs Layout`, and `AI-Agent Docs Review` for AI-agent docs.
 - [documentation checklist](../checklists/documentation.md)
 - [task-analyst role](./task-analyst.md) — load when the docs request is broad or missing audience.
 - [code-review role](./code-review.md) — load when docs are part of a broader review.
@@ -23,6 +23,7 @@ Document real behavior, workflows, APIs, migrations, and decisions with concise,
 - Docs updated and behavior documented.
 - Examples, migration notes, validation, sources checked.
 - Recency window used for AI-agent guidance updates.
+- AI-agent structural review findings and structure recommendation when AI-agent guidance is in scope.
 - Remaining docs gaps.
 
 ## Boundaries

--- a/.agents/checklists/documentation.md
+++ b/.agents/checklists/documentation.md
@@ -10,4 +10,6 @@
 - The update is scoped to the change and avoids broad unrelated rewrites.
 - Root AI instruction files stay thin; detailed workflows live in skills, while commands and tool adapters stay short and route to the shared source.
 - Tool-specific adapters link back to shared guidance instead of duplicating it.
-- For AI-agent guidance, the Freshness Window in [skills/update-docs/SKILL.md](../skills/update-docs/SKILL.md) was followed and the recency window used was reported (or lack of docs access was stated).
+- For AI-agent guidance, the `Freshness Window` and `AI-Agent Docs Review` in [skills/update-docs/SKILL.md](../skills/update-docs/SKILL.md) were followed and the recency window used was reported (or lack of docs access was stated).
+- AI-agent docs match the `AI-Agent Docs Layout` (skills canonical, commands thin, agents thin role specs, checklists compact, rules short, `.claude/`/other adapters thin); deviations are flagged with a keep-or-change recommendation, not silently restructured.
+- AI-agent docs were scanned for duplicated guidance, stale links, stale references to removed/renamed surfaces, and overgrown files.

--- a/.agents/commands/update-docs.md
+++ b/.agents/commands/update-docs.md
@@ -6,7 +6,7 @@ Use this as a runnable prompt for documentation updates.
 
 1. Read `AGENTS.md` and the rules under `.agents/rules/`.
 2. Read and follow [.agents/skills/update-docs/SKILL.md](../skills/update-docs/SKILL.md).
-3. For AI-agent guidance, follow the `Freshness Window` section in that skill before editing; report sources checked and the recency window used.
+3. For AI-agent guidance, follow the `Freshness Window` and `AI-Agent Docs Review` sections in that skill before editing; report sources checked, the recency window used, and any structure recommendation.
 4. Update `docs/CURRENT_TASK_CONTEXT.md` with [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) after meaningful documentation changes.
 
 ## User Input
@@ -20,4 +20,5 @@ Use the command arguments or latest user message as the documentation brief. Inc
 - Examples or migration notes.
 - Validation/source checked.
 - AI-agent best-practice and recent-change sources checked, when applicable.
+- AI-agent structural review findings and structure recommendation, when applicable.
 - Remaining gaps.

--- a/.agents/skills/backend-api-change/SKILL.md
+++ b/.agents/skills/backend-api-change/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Backend API Change

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Code Review

--- a/.agents/skills/commit-preparation/SKILL.md
+++ b/.agents/skills/commit-preparation/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Commit Preparation

--- a/.agents/skills/configuring-mcp/SKILL.md
+++ b/.agents/skills/configuring-mcp/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Configuring MCP

--- a/.agents/skills/current-task-context/SKILL.md
+++ b/.agents/skills/current-task-context/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Current Task Context

--- a/.agents/skills/data-storage-change/SKILL.md
+++ b/.agents/skills/data-storage-change/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Data Storage Change

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Debug

--- a/.agents/skills/designing-hooks/SKILL.md
+++ b/.agents/skills/designing-hooks/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Designing Hooks

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Implement

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Plan

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Refactor

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -38,10 +38,20 @@ Keep documentation accurate, concise, and tied to real code behavior.
 
 ## Surface Routing
 
-- Portable AI-agent guidance belongs in `.agents/`.
-- Tool-specific adapters belong in `AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.codex/`, or `.github/` and should point back to `.agents/` instead of duplicating it.
+- Portable AI-agent guidance belongs in `.agents/`. See `AI-Agent Docs Layout` below for the canonical surface rules.
 - Product, setup, API, and learning docs belong under `docs/` or the nearest package/app README.
-- Use commands as short invocable prompts that route to skills; keep procedural source of truth in skills.
+
+## AI-Agent Docs Layout
+
+Single source of truth for the AI-agent docs structure. Other files reference this section instead of restating it.
+
+- `.agents/skills/` is the canonical home for reusable workflows. Put durable step-by-step procedures here first.
+- `.agents/commands/` are short runnable prompts that route to skills. Commands must not duplicate skill bodies.
+- `.agents/agents/` are thin role specs (`Purpose`, `When To Load`, `Pairs With`, `Output Contributions`, `Boundaries`). Roles do not restate skill workflows.
+- `.agents/checklists/` are compact, scannable verification criteria. Checklists list checks, not procedures.
+- `.agents/rules/` are short because every agent loads them on every session. Keep wording tight.
+- `.claude/`, `.codex/`, `.cursor/`, `.github/` adapters are thin pointers into `.agents/`. They never copy skill bodies.
+- `AGENTS.md` and `CLAUDE.md` are thin entry points; they import or link `.agents/` and do not contain workflows.
 
 ## Freshness Window
 
@@ -59,13 +69,27 @@ Use this rule for AI tools, libraries, framework versions, CLIs, cloud APIs, sec
 5. If web access or docs lookup is unavailable, say so and do not claim the update is freshness-verified.
 6. In the final response, list sources checked, the recency window used, and any meaningful old-to-new guidance changes.
 
+## AI-Agent Docs Review
+
+Run this when the change touches AI-agent guidance (`.agents/`, `.claude/`, `.codex/`, `.cursor/`, `.github/`, `AGENTS.md`, `CLAUDE.md`, related context files, or any skill/agent/command/checklist/rule).
+
+1. Inspect the in-scope files plus their neighbors: `.agents/**`, `.claude/**`, `.codex/**`, `.cursor/**`, `.github/**`, `AGENTS.md`, `CLAUDE.md`.
+2. Run the `Freshness Window` above first. Check current official best practices before editing.
+3. Compare the current layout against `AI-Agent Docs Layout` and the latest official guidance:
+   - If official docs or recent best practices suggest a materially better folder or file structure, point it out explicitly, describe the trade-off, and recommend whether to keep or change the current structure. Do not silently restructure.
+4. Look for duplicated guidance across skills, commands, agents, checklists, rules, and tool adapters. Move durable content into the matching skill and leave other surfaces as thin pointers.
+5. Look for stale links, stale references to removed or renamed folders/skills/commands, broken relative paths, and dead anchors.
+6. Look for overgrown files: rules longer than they need to be (always-loaded cost), commands restating workflows, role specs restating procedures, checklists that explain instead of check, or `.claude/`/other adapters copying skill bodies. Trim them.
+7. Apply cross-tool updates to `.agents/` first; update tool adapters as thin pointers afterward.
+8. Preserve frontmatter contracts: skill `name` matches its folder name; required adapter fields stay valid.
+
 ## Workflow
 
 1. Inspect the changed code and nearby docs before editing.
 2. Identify the audience: user, contributor, operator, reviewer, or future maintainer.
 3. Identify the documentation surface and read the index that lists it, such as `.agents/README.md` or a docs index.
-4. Check whether the file or subject is stale; if it touches drift-prone tools or AI-agent guidance, run the Freshness Window above before editing.
-5. For AI-agent guidance specifically, also compare current guidance against repo files for AGENTS.md, skills, subagents, commands, prompts, hooks, MCP, memory/rules, and tool adapters. Look for naming drift, frontmatter changes, obsolete locations, duplicated instructions, bloated always-loaded context, and unsafe hook or MCP examples. Apply useful cross-tool updates to `.agents/` first; keep root files and tool adapters thin.
+4. Check whether the file or subject is stale; if it touches drift-prone tools or AI-agent guidance, run the `Freshness Window` above before editing.
+5. For AI-agent guidance, also run the `AI-Agent Docs Review` above before editing.
 6. Prefer editing an existing file. Create a new file only when no existing file fits.
 7. Update the smallest relevant doc surface and keep headings, tone, and length consistent.
 8. Keep indexes and relative links in sync.
@@ -82,6 +106,8 @@ Use this rule for AI tools, libraries, framework versions, CLIs, cloud APIs, sec
 - Examples or migration notes added.
 - Validation or source checked.
 - AI-agent best-practice and recent-change sources checked, when applicable.
+- AI-agent structural review findings: duplicates removed, stale links/references fixed, overgrown files trimmed, when applicable.
+- Structure recommendation (keep current vs. change), with trade-off, when official docs suggest a materially better layout.
 - Remaining documentation gaps.
 
 ## Safety Rules
@@ -93,6 +119,7 @@ Use this rule for AI tools, libraries, framework versions, CLIs, cloud APIs, sec
 - Do not present old community examples, marketplace listings, or blog posts as current best practice unless they are clearly secondary and still match official docs.
 - Do not duplicate shared `.agents/` guidance in tool-specific adapters.
 - Do not keep README-only folders when their useful content belongs in a skill.
+- Do not silently restructure AI-agent folders. Surface the trade-off and recommend keep-or-change first.
 
 ## When Not To Use
 

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Update Docs

--- a/.agents/skills/validate/SKILL.md
+++ b/.agents/skills/validate/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-04-25'
+  last-reviewed: '2026-04-26'
 ---
 
 # Validate

--- a/.claude/agents/update-docs.md
+++ b/.claude/agents/update-docs.md
@@ -17,6 +17,7 @@ Before editing docs, read the canonical project instructions:
 - `.agents/agents/update-docs.md`
 
 Follow `.agents/agents/update-docs.md` as the source of truth and the
-`Freshness Window` section in `.agents/skills/update-docs/SKILL.md` whenever
-AI-agent guidance is in scope. Keep portable guidance in `.agents/` and keep
-Claude-specific files as thin adapters.
+`Freshness Window`, `AI-Agent Docs Layout`, and `AI-Agent Docs Review` sections
+in `.agents/skills/update-docs/SKILL.md` whenever AI-agent guidance is in
+scope. Keep portable guidance in `.agents/` and keep Claude-specific files as
+thin adapters.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -13,5 +13,5 @@ When this skill is selected:
 1. Read `AGENTS.md`.
 2. Read `.agents/README.md` and the rules under `.agents/rules/`.
 3. Read `.agents/skills/update-docs/SKILL.md`.
-4. Follow the `.agents` skill as the source of truth, including its `Freshness Window` section for AI-agent docs.
+4. Follow the `.agents` skill as the source of truth, including its `Freshness Window`, `AI-Agent Docs Layout`, and `AI-Agent Docs Review` sections for AI-agent docs.
 5. Document only behavior that was implemented or verified.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,52 @@
 # Node.js Backend Mastery
 
-<!-- TODO: review and adjust it -->
-
-A practical and well-structured knowledge base for building scalable, secure, and maintainable backend systems with Node.js.
+A practical, structured workspace for building scalable, secure, and maintainable backend systems with Node.js. The repo pairs a topic-by-topic learning roadmap with real apps that exercise the patterns end to end.
 
 ## Purpose
 
-This repository is designed as a professional reference for developers looking to deepen their expertise in Node.js backend engineering. It covers core concepts, architecture patterns, and hands-on examples reflecting real-world practices.
+A personal reference for senior-level Node.js backend engineering: real apps over slides, production patterns over toy snippets, and notes that grow alongside the code rather than after it.
 
-## Topics Covered
+## Topics In Scope
 
-- API design (REST & GraphQL)
-- Authentication & Authorization
-- SQL & NoSQL database integrations
-- Clean architecture & DDD principles
-- Error handling, logging, and monitoring
-- Caching, queues, and event-driven patterns
-- Testing (unit & integration)
-- Docker, CI/CD, and deployment workflows
-- Performance tuning and scalability strategies
-- Cloud integration (AWS), environment management
-- Security best practices and data protection
-- Input validation and middleware patterns
+The full topic tree, status, and per-topic notes live in [docs/README.md](docs/README.md). Areas covered include:
 
-## Structure
+- Core Node.js: event loop, streams, child processes
+- Frameworks: Express, Fastify, NestJS
+- API design: REST, WebSockets, GraphQL, gRPC
+- Architecture: MVC, feature-based, hexagonal, clean, DDD, CQRS
+- Auth & security: sessions, JWT, OAuth/OIDC, RBAC/ABAC, rate limiting, secrets
+- Data storage: PostgreSQL, Redis, DynamoDB, MongoDB
+- Async processing: event-driven, BullMQ, scheduled jobs
+- Microservices: API gateway, Kafka, idempotency, sagas
+- Cloud: AWS (ECS, Lambda, S3/CloudFront), GCP, Azure
+- DevOps: Docker, GitHub Actions, Terraform, Kubernetes
+- Observability: Pino logging, Prometheus, OpenTelemetry, Grafana
+- Testing & quality: Vitest/Jest units, integration, contract, mutation, static analysis
 
-Each module includes:
+Most topics are still `todo` or `partial`; flip status in the same PR as the code.
 
-- Concise theory and implementation notes
-- Realistic code examples
+## Repository Layout
+
+- [docs/](docs/) — learning roadmap and per-topic notes; start at [docs/README.md](docs/README.md).
+- [workspaces/apps/](workspaces/apps/) — runnable apps that exercise the patterns. Active: [shop-mvc-express](workspaces/apps/shop-mvc-express/), [local-llm-playground](workspaces/apps/local-llm-playground/). Other folders (and anything under `_todo/`) are scaffolds.
+- [workspaces/packages/](workspaces/packages/) — shared libraries: [config](workspaces/packages/config/), [errors](workspaces/packages/errors/).
+- [.agents/](.agents/) — AI-agent toolkit (rules, skills, agents, commands, checklists) shared by Codex, Claude Code, and Cursor. Entry point: [AGENTS.md](AGENTS.md).
+
+## Tooling
+
+- Package manager: `pnpm@10.33.0`
+- Runtime: Node.js `>=22` (see [.nvmrc](.nvmrc))
+- Workspaces: declared in [pnpm-workspace.yaml](pnpm-workspace.yaml)
+
+Common root scripts:
+
+```bash
+pnpm install
+pnpm run lint
+pnpm run format:check
+pnpm run typecheck
+pnpm run test
+pnpm run build
+```
+
+Use pnpm filters for app-specific work, for example `pnpm --filter local-llm-playground dev`.


### PR DESCRIPTION
## Summary

- Expanded the root README with a clearer repository purpose, topic scope, layout, and common tooling commands.
- Updated AI-agent documentation guidance for shared `.agents/` workflows and thin tool-specific adapters.
- Added review guardrails for AI-agent docs refreshes, including official-source freshness checks.
- Refreshed baseline skill `last-reviewed` metadata.

## Motivation

Keep the repository entry points easier to navigate and make the AI-agent documentation workflow more explicit, auditable, and consistent across Codex, Claude Code, and shared agent guidance.

## Changes

- Clarifies the repo roadmap, active apps, scaffold areas, shared packages, and pnpm commands in `README.md`.
- Updates `.agents/README.md`, update-docs command/skill/checklist files, and Claude adapter docs.
- Documents AI-agent docs layout rules and freshness-window expectations.
- Updates skill metadata review dates to `2026-04-26`.

## Validation

- `git diff --cached --check` passed.
- `git diff --check` passed.
- Targeted docs review completed against the repo docs roadmap and staged changes.

## Risks

- Documentation-only change; no runtime behavior expected.
- Branch combines root repo docs with AI-agent docs, so reviewers may want to scan by file group.

## Rollback

- Revert the branch commits to restore the previous README and AI-agent docs guidance.

## Checklist

- [x] Diff is documentation-focused.
- [x] Relevant validation was run.
- [x] No app code, migrations, or dependency changes.
- [x] No breaking changes.
