### PR TITLE
feat(llm-chat): add Anthropic-backed chat CLI workspace

### DIFF
--- a/.agents/rules/repo-map.md
+++ b/.agents/rules/repo-map.md
@@ -8,6 +8,7 @@ Project-specific orientation for AI agents. Keep this file easy to edit when cop
 - Runtime: Node.js `>=22`.
 - Monorepo workspaces are declared in `pnpm-workspace.yaml`.
 - Apps live under `workspaces/apps/*`.
+- AI engineering learning examples live under `workspaces/ai-engineering/*`.
 - Shared packages live under `workspaces/packages/*`.
 - Docs live under `docs/*`.
 - Shared AI-agent material lives under `.agents/*`. Tool-specific adapters live under `.claude/`, `.codex/`, `.cursor/`, or `.github/` and should stay thin (see [.agents/README.md](../README.md) for design rules).
@@ -18,6 +19,10 @@ Project-specific orientation for AI agents. Keep this file easy to edit when cop
 - `workspaces/apps/local-llm-playground`: Express backend with a Vite/React client and shared schemas.
 - README-only app scaffolds are not production-ready and are not expected to build unless their package config says otherwise.
 - Anything under `_todo`, scratch, or placeholder areas should not be treated as production-ready.
+
+## AI Engineering
+
+- `workspaces/ai-engineering/llm-chat`: provider-neutral LLM chat CLI with an Anthropic adapter.
 
 ## Packages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,12 @@ concurrency:
 
 jobs:
   detect:
-    name: Detect changed apps
+    name: Detect changed workspaces
     runs-on: ubuntu-latest
     outputs:
-      apps: ${{ steps.detect.outputs.apps }}
+      workspaces: ${{ steps.detect.outputs.workspaces }}
       any: ${{ steps.detect.outputs.any }}
+      root_build: ${{ steps.detect.outputs.root_build }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,30 +52,43 @@ jobs:
             fi
             head="${{ github.sha }}"
           else
-            echo "apps=[]" >> "$GITHUB_OUTPUT"
+            echo "workspaces=[]" >> "$GITHUB_OUTPUT"
             echo "any=false" >> "$GITHUB_OUTPUT"
+            echo "root_build=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           mapfile -t files < <(git diff --name-only "$base" "$head" || true)
-          declare -A seen=()
           uniq=()
+          seen_paths=$'\n'
+          root_build=false
           for f in "${files[@]}"; do
-            if [[ "$f" =~ ^workspaces/apps/([^/]+)/ ]]; then
-              app="${BASH_REMATCH[1]}"
-              if [[ -z "${seen[$app]+x}" ]]; then
-                uniq+=("$app")
-                seen[$app]=1
+            case "$f" in
+              .github/workflows/ci.yml | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | tsconfig.base.json)
+                root_build=true
+                ;;
+            esac
+
+            if [[ "$f" =~ ^workspaces/(apps|ai-engineering|packages)/([^/]+)/ ]]; then
+              workspace_path="workspaces/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+              if [[ "$seen_paths" != *$'\n'"$workspace_path"$'\n'* ]]; then
+                workspace_name="$(jq -r '.name // empty' "$workspace_path/package.json" 2>/dev/null || true)"
+                if [[ -z "$workspace_name" ]]; then
+                  continue
+                fi
+                uniq+=("$workspace_name"$'\t'"$workspace_path")
+                seen_paths+="$workspace_path"$'\n'
               fi
             fi
           done
           if [[ "${#uniq[@]}" -eq 0 ]]; then
-            echo "apps=[]" >> "$GITHUB_OUTPUT"
+            echo "workspaces=[]" >> "$GITHUB_OUTPUT"
             echo "any=false" >> "$GITHUB_OUTPUT"
           else
-            apps_json=$(printf '%s\n' "${uniq[@]}" | jq -R -s -c 'split("\n")[:-1]')
-            echo "apps=$apps_json" >> "$GITHUB_OUTPUT"
+            workspaces_json=$(printf '%s\n' "${uniq[@]}" | jq -R -s -c 'split("\n")[:-1] | map(split("\t") | {name: .[0], path: .[1]})')
+            echo "workspaces=$workspaces_json" >> "$GITHUB_OUTPUT"
             echo "any=true" >> "$GITHUB_OUTPUT"
           fi
+          echo "root_build=$root_build" >> "$GITHUB_OUTPUT"
 
   quality:
     name: Lint / Format / Types / Unit
@@ -103,8 +117,8 @@ jobs:
       - name: Unit tests
         run: pnpm run test
 
-  app:
-    name: Build ${{ matrix.app }}
+  workspace:
+    name: Check ${{ matrix.workspace.path }}
     needs: [detect, quality]
     if: needs.detect.outputs.any == 'true'
     runs-on: ubuntu-latest
@@ -112,7 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [22.x]
-        app: ${{ fromJSON(needs.detect.outputs.apps) }}
+        workspace: ${{ fromJSON(needs.detect.outputs.workspaces) }}
     steps:
       - uses: actions/checkout@v4
       - name: Enable Corepack (pnpm)
@@ -125,14 +139,37 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - name: Install deps
         run: pnpm install --frozen-lockfile
-      - name: Lint ${{ matrix.app }}
-        run: pnpm -w --filter ./workspaces/apps/${{ matrix.app }}... run --if-present lint
-      - name: Typecheck ${{ matrix.app }}
-        run: pnpm -w --filter ./workspaces/apps/${{ matrix.app }}... run --if-present typecheck
-      - name: Test ${{ matrix.app }}
-        run: pnpm -w --filter ./workspaces/apps/${{ matrix.app }}... run --if-present test
-      - name: Build ${{ matrix.app }}
-        run: pnpm -w --filter ./workspaces/apps/${{ matrix.app }}... run build
+      - name: Lint ${{ matrix.workspace.path }}
+        run: pnpm --filter "${{ matrix.workspace.name }}" run --if-present lint
+      - name: Typecheck ${{ matrix.workspace.path }}
+        run: pnpm --filter "${{ matrix.workspace.name }}" run --if-present typecheck
+      - name: Test ${{ matrix.workspace.path }}
+        run: pnpm --filter "${{ matrix.workspace.name }}" run --if-present test
+      - name: Build ${{ matrix.workspace.path }}
+        run: pnpm --filter "${{ matrix.workspace.name }}" run --if-present build
+
+  root-build:
+    name: Build all workspaces
+    needs: [detect, quality]
+    if: needs.detect.outputs.root_build == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable Corepack (pnpm)
+        run: corepack enable
+      - name: Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Build all workspaces
+        run: pnpm run build
 
   security:
     name: Audit / Gitleaks

--- a/docs/_todo/api-design/graphql/README.md
+++ b/docs/_todo/api-design/graphql/README.md
@@ -3,6 +3,7 @@
 **Category:** api-design · **Primary app:** — · **Prereqs:** rest · **Status:** todo
 
 ## Scope
+
 - Schema-first vs code-first (e.g. Pothos, Nexus, type-graphql).
 - Query / mutation / subscription shapes; resolver chain.
 - Dataloader for N+1 mitigation.
@@ -10,17 +11,20 @@
 - Trade-offs vs REST: over-fetching, caching, tooling.
 
 ## Sub-tasks
+
 - [ ] Build a minimal GraphQL server over one existing Postgres model; add dataloader.
 - [ ] Compare REST vs GraphQL request volume for the same client feature; note caching implications.
 - [ ] Document authorization story: field-level vs resolver-level.
 
 ## Concepts to know
+
 - Persisted queries + APQ to regain HTTP caching.
 - Query complexity / depth limiting as the GraphQL equivalent of rate limiting.
 - Federation / schema stitching — when multiple GraphQL services exist.
 - Subscriptions typically ride WebSockets or SSE.
 
 ## Interview questions
+
 - When does GraphQL beat REST? When does it not?
 - How do you protect a GraphQL server from expensive queries?
 - Explain the N+1 pattern in resolvers and the dataloader fix.

--- a/docs/_todo/api-design/grpc/README.md
+++ b/docs/_todo/api-design/grpc/README.md
@@ -3,23 +3,27 @@
 **Category:** api-design · **Primary app:** — · **Prereqs:** rest · **Status:** todo
 
 ## Scope
+
 - Protobuf schema, code-gen, and the wire format.
 - Unary / server-streaming / client-streaming / bidi.
 - HTTP/2 multiplexing and flow control.
 - When to pick gRPC over REST: internal service-to-service, typed contracts, streaming.
 
 ## Sub-tasks
+
 - [ ] Define a proto for one shop call; generate TS stubs.
 - [ ] Stand up a gRPC server + client in-repo; measure latency vs REST for the same call.
 - [ ] Document tooling pain: browser support, debugging, observability.
 
 ## Concepts to know
+
 - gRPC-Web and Connect as browser-friendly alternatives.
 - Deadlines/timeouts are first-class; propagate through call chain.
 - Interceptors for auth, logging, tracing.
 - No native caching — gRPC is request/response inside HTTP/2, not cache-friendly.
 
 ## Interview questions
+
 - When would you use gRPC instead of REST between services?
 - Explain the four RPC types and give an example use case for each.
 - What do you lose by moving from REST to gRPC?

--- a/docs/_todo/api-design/realtime-patterns/README.md
+++ b/docs/_todo/api-design/realtime-patterns/README.md
@@ -3,24 +3,28 @@
 **Category:** api-design · **Primary app:** [chat-ws](../../../../workspaces/apps/chat-ws/) · **Prereqs:** websockets · **Status:** todo
 
 ## Scope
+
 - Long-polling, Server-Sent Events (SSE), WebSockets — trade-offs.
 - Horizontal scale with Redis pub/sub, Kafka, or NATS.
 - Presence tracking in Redis hash with TTL-refreshed heartbeats.
 - Message ordering and delivery guarantees across instances.
 
 ## Sub-tasks
+
 - [ ] Wire Redis pub/sub so a publish from any chat-ws instance reaches all subscribed instances.
 - [ ] Document the horizontal-scale story in this README: publisher → bus → subscribers → clients.
 - [ ] Track presence per room as a Redis hash; expire on heartbeat stall.
 - [ ] Sketch what would change if you swapped Redis pub/sub for Kafka (durability, replay).
 
 ## Concepts to know
+
 - SSE is one-way, simpler through proxies, no upgrade — often the right default.
 - Long-poll is the universal fallback; costs more per message.
 - Redis pub/sub is at-most-once; use Streams if you need at-least-once + replay.
 - "Exactly-once" is a lie outside a single transaction; design idempotent consumers.
 
 ## Interview questions
+
 - SSE vs WebSockets vs long-poll — decision framework.
 - Describe your horizontal-scale design for a chat service. Where's the single point of failure?
 - Why does Redis pub/sub lose messages? When is that acceptable, when not?

--- a/docs/_todo/api-design/rest/README.md
+++ b/docs/_todo/api-design/rest/README.md
@@ -3,6 +3,7 @@
 **Category:** api-design · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/), [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** express · **Status:** partial
 
 ## Scope
+
 - Resource-based URLs, HTTP verbs, status codes.
 - Idempotency of verbs; idempotency keys for unsafe writes.
 - Versioning strategy (URL `/v1`, header, or query) and trade-offs.
@@ -11,6 +12,7 @@
 - OpenAPI from Zod schemas.
 
 ## Sub-tasks
+
 - [ ] Implement product CRUD with Zod validation + 4xx/5xx mapping through HttpError (shop-mvc-express).
 - [ ] Add cursor-based pagination for product listing; reject invalid cursors with 400.
 - [ ] Pick a versioning strategy and write a one-page ADR in this folder.
@@ -18,6 +20,7 @@
 - [ ] Add idempotency-key support on `POST /orders` (link to [microservices/idempotency-retries](../../microservices/idempotency-retries/)).
 
 ## Concepts to know
+
 - PUT/DELETE idempotent; POST is not (unless you make it with a key).
 - Cursor pagination wins over offset at large N; encodes `(last_sort_key, last_id)`.
 - Always return a stable error shape; log a server-side correlation ID.
@@ -25,6 +28,7 @@
 - HATEOAS is rarely worth it for internal APIs.
 
 ## Interview questions
+
 - Design the REST surface for orders + payments. Which endpoints are idempotent?
 - How do you version a public API without breaking mobile clients?
 - Client retries a payment POST — how do you prevent double-charging?

--- a/docs/_todo/api-design/websockets/README.md
+++ b/docs/_todo/api-design/websockets/README.md
@@ -3,6 +3,7 @@
 **Category:** api-design · **Primary app:** [chat-ws](../../../../workspaces/apps/chat-ws/) · **Prereqs:** event-loop · **Status:** todo
 
 ## Scope
+
 - WebSocket handshake (HTTP Upgrade), frames, ping/pong.
 - Raw `ws` vs socket.io — what socket.io adds (rooms, auto-reconnect, fallback).
 - Rooms, presence, typing indicators.
@@ -10,6 +11,7 @@
 - Graceful disconnect and reconnection strategy.
 
 ## Sub-tasks
+
 - [ ] Scaffold chat-ws on Fastify + `@fastify/websocket` (or socket.io).
 - [ ] Authenticate the upgrade using an access JWT (query param or protocol header).
 - [ ] Implement room join/leave; broadcast messages within a room.
@@ -18,12 +20,14 @@
 - [ ] Drain sockets on SIGTERM before process exit.
 
 ## Concepts to know
+
 - WebSockets hold a long-lived TCP connection; count them against file descriptors.
 - ALB supports WebSockets; sticky sessions avoid bouncing mid-conversation.
 - Heartbeats detect broken connections the OS hasn't surfaced yet.
 - Horizontal scale needs a message bus (see [../realtime-patterns/](../realtime-patterns/) and [../../data-storage/caching/redis/](../../data-storage/caching/redis/)).
 
 ## Interview questions
+
 - WebSockets vs SSE vs long-polling — how do you choose?
 - How do you authenticate a WebSocket connection?
 - What breaks first when you scale from 10K to 100K concurrent connections?

--- a/docs/_todo/architecture-patterns/clean-architecture/README.md
+++ b/docs/_todo/architecture-patterns/clean-architecture/README.md
@@ -3,21 +3,25 @@
 **Category:** architecture-patterns · **Primary app:** — · **Prereqs:** hexagonal · **Status:** todo
 
 ## Scope
+
 - Four concentric rings: entities → use cases → interface adapters → frameworks/drivers.
 - Dependency rule: source code dependencies only point inward.
 - Use cases as first-class objects; one file per operation.
 
 ## Sub-tasks
+
 - [ ] Re-implement one auth-service feature (login) as a use-case class with explicit port dependencies.
 - [ ] Document the ring boundaries in this file with the actual folder layout you used.
 - [ ] Note the overhead: file count, indirection, onboarding cost.
 
 ## Concepts to know
+
 - Entities are enterprise-wide; use cases are application-specific.
 - Interface adapters translate between use-case shapes and external tech.
 - Frameworks (HTTP, DB clients) live at the outermost ring.
 
 ## Interview questions
+
 - Explain the dependency rule. What does it prevent?
 - When is Clean Architecture over-engineering?
 - How does Clean differ from hexagonal in practice?

--- a/docs/_todo/architecture-patterns/cqrs-event-sourcing/README.md
+++ b/docs/_todo/architecture-patterns/cqrs-event-sourcing/README.md
@@ -3,23 +3,27 @@
 **Category:** architecture-patterns · **Primary app:** — · **Prereqs:** ddd, event-driven · **Status:** todo
 
 ## Scope
+
 - CQRS: split read and write models.
 - Event sourcing: persist the sequence of events, not the current state.
 - Projections rebuild read models from the event stream.
 - When the cost is worth it: audit, temporal queries, complex invariants.
 
 ## Sub-tasks
+
 - [ ] Prototype a single aggregate with event sourcing (appendEvents + replay).
 - [ ] Build a projection that updates a read model from the event stream.
 - [ ] Write the trade-off note: what you pay (complexity, snapshotting, migration) vs what you gain.
 
 ## Concepts to know
+
 - Snapshots avoid replaying millions of events.
 - Upcasters / event versioning when schemas evolve.
 - Read model eventual consistency; design UX for it.
 - Event store choices: EventStoreDB, Postgres append-only table, Kafka.
 
 ## Interview questions
+
 - When would you use event sourcing? When not?
 - Explain CQRS without event sourcing — is it still useful?
 - How do you handle schema evolution in an event-sourced system?

--- a/docs/_todo/architecture-patterns/ddd/README.md
+++ b/docs/_todo/architecture-patterns/ddd/README.md
@@ -3,23 +3,27 @@
 **Category:** architecture-patterns · **Primary app:** — · **Prereqs:** clean-architecture · **Status:** todo
 
 ## Scope
+
 - Tactical patterns: entities, value objects, aggregates, domain services, domain events.
 - Bounded contexts and context maps.
 - Anti-corruption layer for integrating legacy or third-party systems.
 - Ubiquitous language and how it maps to code.
 
 ## Sub-tasks
+
 - [ ] Pick one aggregate root in the shop (e.g. `Order`) and model it with invariants enforced in code.
 - [ ] Emit a domain event on aggregate state change; wire a handler in the application layer.
 - [ ] Write a short context map showing shop / auth / payments boundaries.
 
 ## Concepts to know
+
 - Aggregates enforce invariants; all changes go through the root.
 - Value objects are immutable and equality-by-value.
 - Domain events capture facts; don't confuse with integration events.
-- Eventual consistency *between* aggregates is the norm; strong consistency *within* an aggregate.
+- Eventual consistency _between_ aggregates is the norm; strong consistency _within_ an aggregate.
 
 ## Interview questions
+
 - What is an aggregate root and why does it matter?
 - Difference between a domain event and an integration event.
 - How do you keep aggregates consistent when a transaction touches two of them?

--- a/docs/_todo/architecture-patterns/hexagonal-ports-adapters/README.md
+++ b/docs/_todo/architecture-patterns/hexagonal-ports-adapters/README.md
@@ -3,22 +3,26 @@
 **Category:** architecture-patterns · **Primary app:** [auth-service](../../../../workspaces/apps/auth-service/) · **Prereqs:** feature-based · **Status:** todo
 
 ## Scope
+
 - Domain core defines ports (interfaces); adapters plug in infra (DB, HTTP, queues).
 - Dependency direction: everything points inward to the domain.
 - Testability: in-memory adapters for unit tests, real adapters for integration.
 
 ## Sub-tasks
+
 - [ ] Organize auth-service into `domain/`, `application/`, `adapters/`.
 - [ ] Define ports: `UserRepository`, `TokenStore`, `Mailer`, `OAuthClient`.
 - [ ] Write the authN use-cases as pure functions / classes depending only on ports.
 - [ ] Provide in-memory adapters for testing and Postgres/Redis/SES adapters for prod.
 
 ## Concepts to know
+
 - Keep framework types (Fastify req/res) out of the domain layer.
 - Adapters own validation + serialization at the edge.
 - Hexagonal is feature-based with stronger internal boundaries.
 
 ## Interview questions
+
 - Explain ports and adapters. What does it buy you over plain layered?
 - When does hexagonal become over-engineering?
 - How do you test the domain layer vs the adapters?

--- a/docs/_todo/architecture-patterns/mvc-layered/README.md
+++ b/docs/_todo/architecture-patterns/mvc-layered/README.md
@@ -3,24 +3,28 @@
 **Category:** architecture-patterns · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/), [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** express · **Status:** partial
 
 ## Scope
+
 - Classic MVC / layered: controllers → services → repositories → models.
 - Feature-based (vertical slice): a folder per feature, each self-contained.
 - Repository pattern: services depend on interfaces, not DB clients.
 - Where to put cross-cutting concerns (logging, auth, tracing) in each layout.
 
 ## Sub-tasks
+
 - [ ] Keep shop-mvc-express on layered MVC; document the final module boundaries.
 - [ ] In shop-feature-fastify, create `src/modules/{products,users,orders,cart}` as Fastify plugins.
 - [ ] Add a `Repository` interface per module; inject implementation in the plugin root.
 - [ ] Write a short ADR in this file comparing MVC vs feature-based for the shop.
 
 ## Concepts to know
+
 - MVC can degrade into "fat controllers" as features grow.
 - Feature-based isolates change surface; easier to extract to a microservice later.
 - Repository pattern costs indirection — only worth it when you actually swap or mock the store.
 - DI can be manual (constructor args) or container-based; both fine at this scale.
 
 ## Interview questions
+
 - Compare MVC vs feature-based. Why did you pick feature-based for v2?
 - Repository pattern: what does it cost, what does it buy?
 - Where do cross-cutting concerns (logging, auth, tracing) live in your layout?

--- a/docs/_todo/architecture-patterns/service-meshes/README.md
+++ b/docs/_todo/architecture-patterns/service-meshes/README.md
@@ -3,21 +3,25 @@
 **Category:** architecture-patterns · **Primary app:** — · **Prereqs:** microservices · **Status:** todo
 
 ## Scope
+
 - Sidecar proxies (Envoy) and control-plane (Istio, Linkerd, Consul).
 - What the mesh takes off the application: mTLS, retries, timeouts, circuit breaking, routing.
 - Observability: out-of-the-box metrics, traces, access logs.
 - Cost: extra hop, ops complexity, learning curve.
 
 ## Sub-tasks
+
 - [ ] Write a short note on when a mesh pays off (~10+ services, multi-tenancy, compliance).
 - [ ] Compare application-library stability patterns vs mesh-provided ones.
 
 ## Concepts to know
+
 - mTLS at the mesh removes cert handling from apps.
 - Traffic shifting enables canary and blue-green with declarative policy.
 - Not a substitute for good service contracts — a mesh cannot fix bad APIs.
 
 ## Interview questions
+
 - When would you reach for a service mesh?
 - Explain mTLS at the mesh — what's the app not doing anymore?
 - Trade-offs: library-side resilience (opossum, retry helpers) vs mesh-side.

--- a/docs/_todo/async-processing/schedule-cron/README.md
+++ b/docs/_todo/async-processing/schedule-cron/README.md
@@ -3,22 +3,26 @@
 **Category:** async-processing · **Primary app:** [serverless-toolkit](../../../../workspaces/apps/serverless-toolkit/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - OS cron / systemd timers — single-host only.
 - Node schedulers (`node-cron`, `@nestjs/schedule`) — single-instance only unless coordinated.
 - Distributed: EventBridge rules, BullMQ repeatable jobs, DB-backed locks.
 - Idempotency for re-runs; clock skew considerations.
 
 ## Sub-tasks
+
 - [ ] Implement an EventBridge rule → Lambda daily cleanup in serverless-toolkit.
 - [ ] Make the job idempotent so re-runs on the same day are safe.
 - [ ] Document how you'd do the same thing in an ECS environment (BullMQ vs leader election).
 
 ## Concepts to know
+
 - Multiple app instances running node-cron will all fire — use a distributed lock or external scheduler.
 - EventBridge is at-least-once; assume duplicates can fire.
 - Timezones: default UTC; surface explicitly in config.
 
 ## Interview questions
+
 - You need a daily report across a fleet of ECS tasks. How do you ensure it runs exactly once?
 - Compare EventBridge schedules vs BullMQ repeatable jobs.
 - Job fires twice due to at-least-once delivery — design so that's safe.

--- a/docs/_todo/auth-security/input-validation/README.md
+++ b/docs/_todo/auth-security/input-validation/README.md
@@ -3,23 +3,27 @@
 **Category:** auth-security · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** express · **Status:** partial
 
 ## Scope
+
 - Zod schemas at every external boundary (HTTP, queue messages, webhooks).
 - Parse, don't validate — reject unknown keys, coerce types.
 - Central error shape for validation failures (422 with field list).
 
 ## Sub-tasks
+
 - [ ] Add Zod parsing to every route handler in shop-mvc-express; no `any` leakage.
 - [ ] Standardize validation error payload: `{ code, field, message }[]`.
 - [ ] Share input schemas with the client when a client exists.
 - [ ] Document why we don't re-validate inside services.
 
 ## Concepts to know
+
 - Validate at boundaries; trust internal code.
 - `.strict()` rejects unknown keys; `.passthrough()` keeps them — choose per-endpoint.
 - Schema + TypeScript infer = single source of truth.
 - Over-sanitization (stripping HTML etc.) is for output, not input.
 
 ## Interview questions
+
 - Where do you validate input and why there?
 - Why parse with Zod instead of a library like Joi? What are the trade-offs?
 - How do you surface validation errors to a client without leaking internals?

--- a/docs/_todo/auth-security/jwt/README.md
+++ b/docs/_todo/auth-security/jwt/README.md
@@ -3,6 +3,7 @@
 **Category:** auth-security · **Primary app:** [auth-service](../../../../workspaces/apps/auth-service/) · **Prereqs:** sessions · **Status:** todo
 
 ## Scope
+
 - JWT structure (header, payload, signature); `HS256` vs `RS256`/`ES256`.
 - Short-lived access tokens + long-lived refresh tokens.
 - Refresh token rotation with reuse detection.
@@ -10,6 +11,7 @@
 - Account lifecycle: email verification, password reset, MFA, and device tracking.
 
 ## Sub-tasks
+
 - [ ] Issue 15-minute access JWT + 7-day refresh token at login.
 - [ ] Store refresh tokens hashed in Postgres with `user_id`, `device_id`, `expires_at`, `revoked_at`.
 - [ ] Implement `/refresh` that invalidates the used row and issues a new pair.
@@ -21,6 +23,7 @@
 - [ ] Add optional TOTP MFA and device/session listing after the core flow works.
 
 ## Concepts to know
+
 - JWT can't be revoked client-side; keep the access TTL short.
 - Asymmetric signing (RS256/ES256) lets verifiers not hold the signing key.
 - Avoid putting mutable state in claims (roles can lag until token refresh).
@@ -29,6 +32,7 @@
 - MFA recovery codes need the same storage treatment as passwords.
 
 ## Interview questions
+
 - Sessions vs JWT — which did you pick and why?
 - Walk through refresh-token rotation. How do you detect a stolen token?
 - `HS256` vs `RS256` — when each?

--- a/docs/_todo/auth-security/oauth-openid/README.md
+++ b/docs/_todo/auth-security/oauth-openid/README.md
@@ -3,12 +3,14 @@
 **Category:** auth-security · **Primary app:** [auth-service](../../../../workspaces/apps/auth-service/) · **Prereqs:** jwt · **Status:** todo
 
 ## Scope
+
 - Authorization Code Grant + PKCE (public clients).
 - OIDC on top of OAuth2: `id_token`, standard claims.
 - State parameter for CSRF protection on the redirect.
 - Upserting the user locally and issuing your own tokens.
 
 ## Sub-tasks
+
 - [ ] Integrate Google (or GitHub) OAuth2 in auth-service.
 - [ ] Implement full flow: `/oauth/start` → provider consent → `/oauth/callback`.
 - [ ] Upsert user by provider + subject; link to existing accounts by verified email.
@@ -16,12 +18,14 @@
 - [ ] Enforce `state` + `nonce` parameters; reject mismatches.
 
 ## Concepts to know
+
 - OAuth2 = authorization; OIDC = authentication on top.
 - PKCE prevents stolen auth codes from being exchanged by an attacker.
 - Never trust the provider's email alone unless it's marked verified.
 - Store provider refresh tokens only if you need offline access.
 
 ## Interview questions
+
 - Walk through an OAuth2 code-grant flow with PKCE.
 - What does the `state` parameter prevent? What about `nonce`?
 - OAuth2 vs OIDC — where exactly is the line?

--- a/docs/_todo/auth-security/rate-limiting/README.md
+++ b/docs/_todo/auth-security/rate-limiting/README.md
@@ -3,24 +3,28 @@
 **Category:** auth-security · **Primary app:** [auth-service](../../../../workspaces/apps/auth-service/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Algorithms: fixed window, sliding window, token bucket, leaky bucket.
 - Distributed limits in Redis (atomic Lua script or `INCR + EXPIRE`).
 - Per-IP, per-user, per-endpoint; combined policies.
 - Account lockout vs soft throttle — when each fits.
 
 ## Sub-tasks
+
 - [ ] Add `express-rate-limit` on auth routes in shop-mvc-express; document limits here.
 - [ ] In auth-service, implement a Redis token-bucket limiter for `login` / `signup` / `reset`.
 - [ ] Expose rate-limit status in response headers (`RateLimit-*`).
 - [ ] Document the chosen thresholds and the reasoning.
 
 ## Concepts to know
+
 - Fixed windows are burstable at boundaries; sliding/token-bucket smoother.
 - Key by `(ip, endpoint)` for anonymous, `(user_id, endpoint)` for authenticated.
 - Always fail-open on the limiter's dependency failure; log loudly.
 - Legit bots (search engines) may hit limits; maintain an allowlist for known IPs if needed.
 
 ## Interview questions
+
 - Compare the four rate-limit algorithms. Which is your default?
 - How do you implement a shared limiter across N app instances?
 - Login endpoint is being brute-forced. Design the response.

--- a/docs/_todo/auth-security/rbac-abac/README.md
+++ b/docs/_todo/auth-security/rbac-abac/README.md
@@ -3,24 +3,28 @@
 **Category:** auth-security · **Primary app:** [auth-service](../../../../workspaces/apps/auth-service/) · **Prereqs:** jwt · **Status:** todo
 
 ## Scope
+
 - RBAC: users → roles → permissions.
 - ABAC: policy evaluates attributes of user, resource, action, environment.
 - Where to enforce: at the gateway, at the service, at the resource.
 - Policy-as-code (OPA / Cedar) as the step beyond hand-rolled ABAC.
 
 ## Sub-tasks
+
 - [ ] Model `roles` and `permissions` in auth-service; seed `admin` and `user`.
 - [ ] Expose `requirePermission('products:write')` middleware for other services to consume.
 - [ ] Put role claim in access JWT; re-check permission server-side on sensitive routes.
 - [ ] Document where each enforcement point lives in this file.
 
 ## Concepts to know
+
 - Don't scatter `if (role === 'admin')` across the codebase — central predicate.
 - Role in JWT lags reality — re-check from DB for privileged operations.
 - ABAC is more flexible but harder to reason about; pick when policies depend on resource attrs.
 - Least privilege: default-deny, grant explicitly.
 
 ## Interview questions
+
 - Design RBAC for a multi-tenant shop.
 - Where does the authorization decision live? Why there?
 - RBAC vs ABAC — when is the added flexibility worth it?

--- a/docs/_todo/auth-security/secret-management/README.md
+++ b/docs/_todo/auth-security/secret-management/README.md
@@ -3,12 +3,14 @@
 **Category:** auth-security · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** aws · **Status:** todo
 
 ## Scope
+
 - AWS Secrets Manager vs SSM Parameter Store.
 - IAM-based access with least privilege; OIDC for CI/CD instead of static keys.
 - Rotation strategies (automatic vs manual).
 - Local dev vs prod: `.env` local only, never committed.
 
 ## Sub-tasks
+
 - [ ] Store DB + Redis credentials for shop-feature-fastify in Secrets Manager.
 - [ ] Inject as environment variables into the ECS task definition via `secrets:` block.
 - [ ] Write a minimal IAM policy allowing only `GetSecretValue` for the app's prefix.
@@ -16,12 +18,14 @@
 - [ ] Document the rotation plan (automatic for RDS, manual for API keys).
 
 ## Concepts to know
+
 - SSM Parameter Store is cheaper; Secrets Manager has built-in rotation for RDS/Redshift.
 - Never log secret values, even at debug.
 - Git history keeps secrets forever — rotate if ever committed.
 - Container env vars are readable by any process in the container; sensitive values can also be pulled on demand.
 
 ## Interview questions
+
 - How do you manage secrets for a containerized app on ECS?
 - How does a GitHub Action authenticate to AWS without static keys?
 - A secret leaked on GitHub — first 10 minutes?

--- a/docs/_todo/auth-security/secure-headers/README.md
+++ b/docs/_todo/auth-security/secure-headers/README.md
@@ -3,24 +3,28 @@
 **Category:** auth-security · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** express · **Status:** partial
 
 ## Scope
+
 - Helmet defaults and what each header does.
 - Content Security Policy (CSP): source lists, `nonce`/`hash`, reporting.
 - HSTS, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`.
 - CORS: preflight, credentials, exposed headers.
 
 ## Sub-tasks
+
 - [ ] Keep the current custom CSP in shop-mvc-express; document each directive here.
 - [ ] Enable CSP report-only for a release, then switch to enforcing.
 - [ ] Configure CORS narrowly: explicit origins, credentials only when needed.
 - [ ] Add HSTS with `includeSubDomains` once HTTPS is everywhere.
 
 ## Concepts to know
+
 - CSP is defense-in-depth against XSS, but needs tuning for inline scripts/styles.
 - `unsafe-inline` defeats the point; use `nonce` or `hash` instead.
 - CORS is not a security boundary — it's browser policy.
 - Helmet headers don't protect against server-side vulnerabilities.
 
 ## Interview questions
+
 - Walk through Helmet's defaults and what each header defends against.
 - Design a CSP for an HTML app that needs inline event handlers from a third-party widget.
 - CORS rejects your request — walk me through diagnosis.

--- a/docs/_todo/auth-security/sessions/README.md
+++ b/docs/_todo/auth-security/sessions/README.md
@@ -3,6 +3,7 @@
 **Category:** auth-security · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** express · **Status:** todo
 
 ## Scope
+
 - Email/password registration and login for the monolith baseline.
 - Password hashing with argon2 or bcrypt; never store plaintext or reversible passwords.
 - Server-side session state in Redis (or Postgres).
@@ -11,6 +12,7 @@
 - Session rotation on privilege change (login, password change).
 
 ## Sub-tasks
+
 - [ ] Implement registration + login in shop-mvc-express with hashed passwords.
 - [ ] Decide sessions-or-JWT for shop-mvc-express; record the reasoning here.
 - [ ] If sessions: wire `express-session` + Redis store; set all three cookie flags.
@@ -18,12 +20,14 @@
 - [ ] Add CSRF tokens for form routes (double-submit or synchronizer pattern).
 
 ## Concepts to know
+
 - Argon2id is the default password-hashing choice; bcrypt is acceptable when platform support is simpler.
 - Revoking sessions is trivial (delete the row); JWT revocation is harder.
 - Shared session store is needed for horizontal scale.
 - `SameSite=Lax` defaults block most CSRF; `Strict` breaks cross-site navigation.
 
 ## Interview questions
+
 - How do you store passwords safely? Which parameters matter?
 - Sessions vs JWT — when does sessions win?
 - Why rotate the session ID on login?

--- a/docs/_todo/cloud-services/aws/README.md
+++ b/docs/_todo/cloud-services/aws/README.md
@@ -3,6 +3,7 @@
 **Category:** cloud-services · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** docker · **Status:** todo
 
 ## Scope
+
 - VPC: public vs private subnets, NAT, security groups vs NACLs.
 - ECS Fargate: task definitions, services, auto-scaling, ALB target groups.
 - RDS Postgres: Multi-AZ, read replicas, parameter groups.
@@ -12,6 +13,7 @@
 - CloudWatch Logs / Metrics / Alarms.
 
 ## Sub-tasks
+
 - [ ] Author a CDK (or Terraform) stack: VPC + public/private subnets, ALB, ECS service, RDS, ElastiCache, ECR.
 - [ ] Put RDS and ElastiCache in private subnets; restrict SGs to ECS-only ingress.
 - [ ] Inject secrets from Secrets Manager into the task definition as secret env vars.
@@ -19,11 +21,13 @@
 - [ ] Write the full architecture diagram in this file once applied.
 
 ## Sub-pages
+
 - [lambda-api-gateway/](./lambda-api-gateway/) — serverless HTTP.
 - [s3-cloudfront/](./s3-cloudfront/) — object storage + CDN.
 - [serverless-framework/](./serverless-framework/) — SAM / Serverless FW / CDK for Lambda.
 
 ## Concepts to know
+
 - Public subnet = has IGW route; private subnet = doesn't.
 - Task role = what the task can do; execution role = what ECS can do to start the task.
 - RDS Multi-AZ is HA only; read replicas are read-scale only (not HA).
@@ -31,6 +35,7 @@
 - Grant IAM at the task role; don't hand out credentials.
 
 ## Interview questions
+
 - Draw your shop's AWS architecture. Where is traffic terminated, where do secrets live?
 - Task role vs execution role — what goes in each?
 - Lambda vs ECS Fargate — decision framework (see [lambda-api-gateway](./lambda-api-gateway/)).

--- a/docs/_todo/cloud-services/aws/lambda-api-gateway/README.md
+++ b/docs/_todo/cloud-services/aws/lambda-api-gateway/README.md
@@ -3,6 +3,7 @@
 **Category:** cloud-services/aws · **Primary app:** [serverless-toolkit](../../../../../workspaces/apps/serverless-toolkit/) · **Prereqs:** aws · **Status:** todo
 
 ## Scope
+
 - Lambda execution model: init → invoke; container reuse; cold starts.
 - Provisioned concurrency to cap cold-start latency.
 - API Gateway: HTTP API (v2, cheaper) vs REST API (v1, more features) vs WebSocket API.
@@ -10,6 +11,7 @@
 - Cost model: per-invocation + per-GB-second.
 
 ## Sub-tasks
+
 - [ ] Build a CDK stack: API Gateway (HTTP) → Lambda → DynamoDB CRUD on a simple resource.
 - [ ] Add an EventBridge rule → Lambda daily cleanup job.
 - [ ] Add an SQS queue → Lambda consumer with DLQ and retry policy.
@@ -17,12 +19,14 @@
 - [ ] Write a comparison note: Lambda vs ECS Fargate for the shop APIs.
 
 ## Concepts to know
+
 - Each Lambda instance handles one request at a time (until concurrency is configured).
 - DB connections: Lambda + RDS = connection explosion. Use RDS Proxy.
 - Timeouts: API GW v2 max 30s; Lambda max 15m.
 - Structured logs via stdout go to CloudWatch Logs automatically.
 
 ## Interview questions
+
 - Lambda vs ECS Fargate — when each?
 - Explain the Lambda execution model and what causes cold starts.
 - Why does Lambda+RDS usually need RDS Proxy?

--- a/docs/_todo/cloud-services/aws/s3-cloudfront/README.md
+++ b/docs/_todo/cloud-services/aws/s3-cloudfront/README.md
@@ -3,6 +3,7 @@
 **Category:** cloud-services/aws · **Primary app:** [media-service](../../../../../workspaces/apps/media-service/) · **Prereqs:** aws · **Status:** todo
 
 ## Scope
+
 - S3 storage classes, lifecycle rules.
 - Presigned URLs for direct upload/download.
 - Access control: bucket policy vs ACL vs Origin Access Control (OAC).
@@ -10,17 +11,20 @@
 - Lambda@Edge / CloudFront Functions for header manipulation.
 
 ## Sub-tasks
+
 - [ ] Issue presigned PUT URLs so the client uploads directly to S3.
 - [ ] Put CloudFront in front of S3 using Origin Access Control; block direct bucket access.
 - [ ] Set long `Cache-Control` on fingerprinted assets; short on dynamic.
 - [ ] Process uploaded images with a Lambda triggered from S3 events.
 
 ## Concepts to know
+
 - Presigned URLs encode the requester's identity + expiration.
 - Public buckets are a common leak — default-deny at the account level.
 - CloudFront Functions beat Lambda@Edge for simple header rewrites (cheaper, lower latency).
 
 ## Interview questions
+
 - Design a scalable upload flow. Where does the client send bytes?
 - Explain OAC vs the legacy OAI pattern.
 - How do you serve private files through CloudFront?

--- a/docs/_todo/cloud-services/aws/serverless-framework/README.md
+++ b/docs/_todo/cloud-services/aws/serverless-framework/README.md
@@ -3,22 +3,26 @@
 **Category:** cloud-services/aws · **Primary app:** [serverless-toolkit](../../../../../workspaces/apps/serverless-toolkit/) · **Prereqs:** lambda-api-gateway · **Status:** todo
 
 ## Scope
+
 - AWS CDK (TypeScript) — real code, L2/L3 constructs.
 - AWS SAM — CFN-flavored, Lambda-optimized.
 - Serverless Framework — YAML + plugin ecosystem.
 - When each fits; lock-in implications.
 
 ## Sub-tasks
+
 - [ ] Pick CDK for serverless-toolkit; stand up the stack.
 - [ ] Write a short comparison vs SAM and Serverless FW.
 - [ ] Capture deploy times and developer ergonomics in this file.
 
 ## Concepts to know
+
 - CDK compiles to CloudFormation; you still hit CFN limits.
 - Construct libraries let you encode team conventions as reusable code.
 - SAM and Serverless FW have faster feedback loops for pure Lambda shops.
 
 ## Interview questions
+
 - CDK vs SAM vs Serverless Framework — decision framework.
 - How does CDK handle drift from manual changes?
 - When does Terraform win over any of the AWS-native tools?

--- a/docs/_todo/cloud-services/azure/README.md
+++ b/docs/_todo/cloud-services/azure/README.md
@@ -3,18 +3,22 @@
 **Category:** cloud-services · **Primary app:** — · **Prereqs:** aws · **Status:** todo
 
 ## Scope
+
 - Compute: Container Apps, Functions, AKS.
 - Data: Cosmos DB, Azure SQL, Service Bus.
 - Entra ID (formerly Azure AD) as the identity layer.
 
 ## Sub-tasks
+
 - [ ] Write a 1-page comparison note mapping AWS → Azure equivalents.
 
 ## Concepts to know
+
 - Cosmos DB multi-model with tunable consistency.
 - Azure networking terminology differs (VNet, NSG, App Service Environment).
 - Entra ID often matters more than compute in enterprise Azure deployments.
 
 ## Interview questions
+
 - Container Apps vs Functions vs AKS — decision framework.
 - How does Cosmos DB's consistency model compare to DynamoDB's?

--- a/docs/_todo/cloud-services/gcp/README.md
+++ b/docs/_todo/cloud-services/gcp/README.md
@@ -3,19 +3,23 @@
 **Category:** cloud-services · **Primary app:** — · **Prereqs:** aws · **Status:** todo
 
 ## Scope
+
 - Compute: Cloud Run (containers), Cloud Functions, GKE.
 - Data: Cloud SQL, Spanner, BigQuery, Firestore.
 - Messaging: Pub/Sub, Tasks.
 - IAM differences vs AWS.
 
 ## Sub-tasks
+
 - [ ] Write a 1-page comparison note mapping AWS services → GCP equivalents.
 
 ## Concepts to know
+
 - Cloud Run is the closest Fargate analog; scales to zero cheaply.
 - Spanner gives global strong consistency at cost.
 - Pub/Sub is a managed event bus; closer to Kafka than SNS in shape.
 
 ## Interview questions
+
 - Cloud Run vs ECS Fargate — where does each win?
 - When is Spanner worth the cost over Postgres + sharding?

--- a/docs/_todo/compliance-governance/gdpr/README.md
+++ b/docs/_todo/compliance-governance/gdpr/README.md
@@ -3,23 +3,27 @@
 **Category:** compliance-governance · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Data subject rights: access, rectification, erasure, portability, objection.
 - Lawful basis for processing; consent management.
 - Data retention, minimization, and purpose limitation.
 - Breach notification timelines.
 
 ## Sub-tasks
+
 - [ ] Document what personal data the shop stores and why.
 - [ ] Implement "download my data" and "delete my account" endpoints.
 - [ ] Define retention policy per data type; automate expiry.
 - [ ] Note the breach notification SLA (72 hours to authority).
 
 ## Concepts to know
+
 - "Legitimate interest" is a valid basis but requires a balancing test.
 - Soft delete vs hard delete: erasure requests usually need hard.
 - Backups + GDPR are thorny — document your practical approach.
 
 ## Interview questions
+
 - User invokes right to erasure. Walk through the steps your system takes.
 - How do you keep backups GDPR-compliant?
 - Lawful basis options — when is consent the wrong choice?

--- a/docs/_todo/compliance-governance/pci-dss/README.md
+++ b/docs/_todo/compliance-governance/pci-dss/README.md
@@ -3,22 +3,26 @@
 **Category:** compliance-governance · **Primary app:** [orders-event-driven](../../../../workspaces/apps/orders-event-driven/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Cardholder Data Environment (CDE) scope minimization.
 - Tokenization via a payment provider (Stripe, Adyen) to stay out of scope.
 - SAQ levels; what each requires.
 - Network segmentation, logging, and change control.
 
 ## Sub-tasks
+
 - [ ] Decide: full CDE or tokenized (via provider). Default: tokenized.
 - [ ] Document what data touches your systems and what stays with the provider.
 - [ ] Ensure no PAN or CVV ever hits your logs or DB.
 
 ## Concepts to know
+
 - Holding PANs pulls you into the full PCI scope — avoid when possible.
 - Tokens from providers map to PAN only inside the provider's vault.
-- Logs are in scope if they *could* contain PAN — redact aggressively.
+- Logs are in scope if they _could_ contain PAN — redact aggressively.
 
 ## Interview questions
+
 - How do you stay out of PCI scope while still processing payments?
 - What's tokenization and where does it happen?
 - What goes wrong if PAN appears in a log?

--- a/docs/_todo/compliance-governance/threat-modeling/README.md
+++ b/docs/_todo/compliance-governance/threat-modeling/README.md
@@ -3,21 +3,25 @@
 **Category:** compliance-governance · **Primary app:** [auth-service](../../../../workspaces/apps/auth-service/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - STRIDE: Spoofing, Tampering, Repudiation, Info disclosure, DoS, Elevation of privilege.
 - Data flow diagrams: actors, boundaries, trust zones.
 - Lightweight formats: 1-page attack surface doc beats unused 30-page artifact.
 
 ## Sub-tasks
+
 - [ ] Run one STRIDE pass on auth-service; identify the top 5 risks with mitigations.
 - [ ] Document assets, entry points, and trust boundaries in this file.
 - [ ] Re-run annually or on major architecture changes.
 
 ## Concepts to know
+
 - Threat models age — treat them as living docs tied to the architecture.
 - Focus on high-impact, realistic threats; don't chase theater.
 - Tie each risk to a mitigation that's either implemented or ticketed.
 
 ## Interview questions
+
 - Walk through a threat model for an auth service.
 - STRIDE categories — name one example for each.
 - How do you keep a threat model from rotting?

--- a/docs/_todo/core-nodejs/child-process-cluster/README.md
+++ b/docs/_todo/core-nodejs/child-process-cluster/README.md
@@ -3,23 +3,27 @@
 **Category:** core-nodejs · **Primary app:** — · **Prereqs:** event-loop · **Status:** todo
 
 ## Scope
+
 - `child_process` (`spawn`, `fork`, `exec`) — when each fits.
 - `worker_threads` — shared memory via `SharedArrayBuffer`, message passing.
 - `cluster` module vs process manager (PM2 / systemd / ECS).
 - When to reach for a separate service instead of workers.
 
 ## Sub-tasks
+
 - [ ] Move one CPU-bound operation (e.g. image resize, PDF render) to a `worker_threads` pool; benchmark.
 - [ ] Write a short note comparing `cluster` with ECS horizontal scaling — when cluster still earns its keep.
 - [ ] Demo `fork` IPC between a parent and a worker with back-and-forth messages.
 
 ## Concepts to know
+
 - Which APIs share memory (`SharedArrayBuffer`) vs copy (postMessage + transfer).
 - Startup cost of a worker vs a process.
 - Why `cluster` doesn't help with a single CPU-bound request.
 - When to pick a separate service (another language, isolation, ops boundary).
 
 ## Interview questions
+
 - When would you use `worker_threads` over a separate process?
 - How does `cluster` differ from running N copies behind a load balancer?
 - A CPU-bound endpoint tanks latency for everything else. Walk through your options.

--- a/docs/_todo/core-nodejs/event-loop/README.md
+++ b/docs/_todo/core-nodejs/event-loop/README.md
@@ -3,18 +3,21 @@
 **Category:** core-nodejs · **Primary app:** all · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Event-loop phases: timers, pending callbacks, poll, check, close.
 - Microtask queue: `process.nextTick` (priority) vs Promise jobs.
 - libuv thread pool and which APIs hit it (`fs`, DNS, crypto, zlib).
 - Non-blocking I/O model: CPU-bound work blocks everything on the main thread.
 
 ## Sub-tasks
+
 - [ ] Write a 1-page note explaining the six phases with a minimal repro per phase.
 - [ ] Add a demo app that intentionally blocks the loop (busy loop + `setTimeout`) and measure observed delay.
 - [ ] Document how `process.nextTick` can starve the I/O phase if mis-used.
 - [ ] Cross-link [../streams-buffering/](../streams-buffering/) and [../child-process-cluster/](../child-process-cluster/) as mitigations for CPU-bound work.
 
 ## Concepts to know
+
 - Phases order and what each one drains.
 - Difference between macrotasks and microtasks in Node vs browsers.
 - `setImmediate` vs `setTimeout(fn, 0)` scheduling.
@@ -22,6 +25,7 @@
 - `AbortController` + signals for cancellable I/O.
 
 ## Interview questions
+
 - How does the event loop handle a CPU-bound loop vs an I/O-bound wait? What blocks what?
 - Why is `process.nextTick` dangerous if mis-used?
 - Explain the difference between `setImmediate` and `setTimeout(fn, 0)`.

--- a/docs/_todo/core-nodejs/native-modules/README.md
+++ b/docs/_todo/core-nodejs/native-modules/README.md
@@ -3,21 +3,25 @@
 **Category:** core-nodejs · **Primary app:** — · **Prereqs:** streams-buffering · **Status:** todo
 
 ## Scope
+
 - Node-API (N-API / node-addon-api) stability contract vs legacy V8 API.
 - When to reach for native: crypto hot paths, bindings to existing C/C++ libs, SIMD.
 - `node-gyp` build pipeline and prebuilt-binary distribution.
 
 ## Sub-tasks
+
 - [ ] Build a trivial N-API addon (string reverse) to practice the build loop.
 - [ ] Benchmark a pure-JS implementation vs the addon to learn when native actually pays.
 - [ ] Document distribution options (prebuildify, node-pre-gyp) and CI matrix for Linux/macOS.
 
 ## Concepts to know
+
 - ABI stability guarantees of N-API across Node versions.
 - Costs: build complexity, cross-platform support, debugging story.
 - When `wasm` is a better answer than a native addon.
 
 ## Interview questions
+
 - When is a native Node addon worth the build-system pain?
 - N-API vs V8 C++ API — why N-API won.
 - How would you ship a native addon to consumers without asking them to compile?

--- a/docs/_todo/core-nodejs/streams-buffering/README.md
+++ b/docs/_todo/core-nodejs/streams-buffering/README.md
@@ -3,24 +3,28 @@
 **Category:** core-nodejs · **Primary app:** media-service · **Prereqs:** event-loop · **Status:** todo
 
 ## Scope
+
 - Readable / Writable / Duplex / Transform stream types.
 - Backpressure via `highWaterMark` and `drain` events.
 - `pipeline` + `finished` for correct error propagation and cleanup.
 - Buffers and binary data; `TextEncoder` / `TextDecoder`.
 
 ## Sub-tasks
+
 - [ ] Build a file-upload endpoint that streams directly to S3 without buffering full request into memory.
 - [ ] Demo a slow-consumer scenario; measure memory with and without `pipeline`.
 - [ ] Write a Transform stream that chunks CSV rows and emits parsed objects.
 - [ ] Document a memory regression you produced intentionally by ignoring backpressure.
 
 ## Concepts to know
+
 - When a Readable emits `data` vs when you pull with `read()`.
 - What "paused" vs "flowing" mode means and how to switch.
 - Why `for await` over an async iterator is usually the cleanest consumer.
 - Error handling: why `.pipe()` leaks vs `pipeline()` cleaning up.
 
 ## Interview questions
+
 - Explain backpressure with a streaming file upload example.
 - Why can `.pipe()` leave resources open on error? What fixes it?
 - When would you write a custom Transform stream instead of processing in-memory?

--- a/docs/_todo/data-storage/caching/cdn-strategies/README.md
+++ b/docs/_todo/data-storage/caching/cdn-strategies/README.md
@@ -3,22 +3,26 @@
 **Category:** data-storage/caching · **Primary app:** [media-service](../../../../../workspaces/apps/media-service/) · **Prereqs:** redis · **Status:** todo
 
 ## Scope
+
 - Edge caching via CloudFront / Cloudflare / Fastly.
 - Cache-Control, ETag, surrogate keys, revalidation.
 - Stale-while-revalidate and stale-if-error.
 - Purge strategies: invalidate by URL, tag, or wildcard.
 
 ## Sub-tasks
+
 - [ ] Put CloudFront in front of S3 for product images; restrict origin access.
 - [ ] Set `Cache-Control` aggressively for immutable assets (fingerprinted URLs).
 - [ ] Write a short note on purge strategy: event-driven vs scheduled.
 
 ## Concepts to know
+
 - Fingerprinted URLs (`image.abcdef.jpg`) sidestep invalidation.
 - Dynamic HTML at the edge is possible but costs correctness if you cache auth'd content.
 - Vary headers expand cache cardinality — use deliberately.
 
 ## Interview questions
+
 - Design the caching layers for a media-heavy e-commerce site.
 - ETag vs Last-Modified — when each?
 - How do you invalidate a CDN when a product image is replaced?

--- a/docs/_todo/data-storage/caching/redis/README.md
+++ b/docs/_todo/data-storage/caching/redis/README.md
@@ -3,6 +3,7 @@
 **Category:** data-storage/caching · **Primary app:** [shop-feature-fastify](../../../../../workspaces/apps/shop-feature-fastify/), [chat-ws](../../../../../workspaces/apps/chat-ws/) · **Prereqs:** postgresql · **Status:** todo
 
 ## Scope
+
 - Cache-aside (lazy loading); write-through; write-behind.
 - TTLs + explicit invalidation on writes.
 - Pub/sub for fan-out (chat, cache invalidation notifications).
@@ -10,6 +11,7 @@
 - Sessions and token blacklist use cases.
 
 ## Sub-tasks
+
 - [ ] Implement cache-aside for product list + detail in shop-feature-fastify (10-minute TTL).
 - [ ] Invalidate keys on product create/update/delete; write a test that proves invalidation.
 - [ ] Benchmark product list with/without cache using autocannon; record numbers in [../../../performance-optimization/benchmarking-autocannon/](../../../performance-optimization/benchmarking-autocannon/).
@@ -17,6 +19,7 @@
 - [ ] Use Redis as a token blacklist keyed by JWT `jti` with TTL == access token expiry.
 
 ## Concepts to know
+
 - Cache invalidation is the hard problem — do it on writes, not on read.
 - Stampede: a hot key expiring triggers many DB reads; mitigate with request coalescing or soft TTL.
 - Pub/sub is at-most-once; Streams are at-least-once with consumer groups.
@@ -24,6 +27,7 @@
 - ElastiCache Redis cluster: single point of failure without Multi-AZ.
 
 ## Interview questions
+
 - Explain cache-aside with pseudo-code. Where does invalidation live?
 - You have a hot product page; describe caching end-to-end including invalidation.
 - Redis pub/sub lost a message. What fixed the design?

--- a/docs/_todo/data-storage/graph-db/README.md
+++ b/docs/_todo/data-storage/graph-db/README.md
@@ -3,19 +3,23 @@
 **Category:** data-storage · **Primary app:** — · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Labeled-property graph model (Neo4j) vs RDF triple stores.
 - When to reach for a graph DB: relationship-heavy queries (social, knowledge, recommendations).
 - Cypher query language basics.
 
 ## Sub-tasks
+
 - [ ] Write a note on when graph beats SQL — recursive / variable-depth traversals.
 - [ ] Sketch a "followers of followers" query in Cypher vs SQL.
 
 ## Concepts to know
+
 - SQL recursive CTEs cover some graph cases but scale poorly past a few levels.
 - Graph DBs are not a general-purpose DB — pick per use-case.
 - Operational story is heavier than Postgres for most teams.
 
 ## Interview questions
+
 - When would you pick Neo4j over Postgres?
 - What queries are painful in SQL but easy in a graph DB?

--- a/docs/_todo/data-storage/nosql/dynamodb/README.md
+++ b/docs/_todo/data-storage/nosql/dynamodb/README.md
@@ -3,6 +3,7 @@
 **Category:** data-storage/nosql · **Primary app:** [serverless-toolkit](../../../../../workspaces/apps/serverless-toolkit/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Partition key + sort key design; access-pattern-first modeling.
 - GSI / LSI; projection trade-offs.
 - On-demand vs provisioned capacity; auto-scaling.
@@ -10,18 +11,21 @@
 - TTL for expiring rows.
 
 ## Sub-tasks
+
 - [ ] List the access patterns for one feature (e.g. notes) before designing the table.
 - [ ] Design a single-table schema with `PK`, `SK`, one GSI, and a TTL attribute.
 - [ ] Implement CRUD via Lambda with the AWS SDK v3.
 - [ ] Wire a DynamoDB stream → Lambda projection for downstream reads.
 
 ## Concepts to know
+
 - Single-table design packs multiple entity types into one table with composite keys.
 - Hot partitions kill throughput; design keys to spread writes.
 - Scans are last resort; always access by key or GSI.
 - Global tables cost money and add conflict-resolution complexity.
 
 ## Interview questions
+
 - Partition key for a `chat_messages` table — pick and justify.
 - How do you model a 1-to-many relationship in DynamoDB?
 - When do you pick DynamoDB over Postgres?

--- a/docs/_todo/data-storage/nosql/mongodb/README.md
+++ b/docs/_todo/data-storage/nosql/mongodb/README.md
@@ -3,6 +3,7 @@
 **Category:** data-storage/nosql · **Primary app:** — · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Document modeling: embed vs reference.
 - Indexes (single, compound, text, TTL).
 - Aggregation pipeline.
@@ -10,16 +11,19 @@
 - Sharding key selection.
 
 ## Sub-tasks
+
 - [ ] Model the shop domain in Mongo as an exercise; note where references beat embedding.
 - [ ] Write a note comparing Mongo vs Postgres for JSON-heavy workloads.
 
 ## Concepts to know
+
 - Embed for containment + read-together; reference when children are independent or large.
 - 16MB document size limit.
 - Shard key is one-way — changing it is expensive.
 - Transactions work but are noticeably slower than the single-document atomic write path.
 
 ## Interview questions
+
 - Embed vs reference — decision framework.
 - How does Mongo's aggregation pipeline compare to SQL?
 - When would you pick Mongo over Postgres + JSONB?

--- a/docs/_todo/data-storage/relational/mysql/README.md
+++ b/docs/_todo/data-storage/relational/mysql/README.md
@@ -3,21 +3,25 @@
 **Category:** data-storage/relational · **Primary app:** — · **Prereqs:** postgresql · **Status:** todo
 
 ## Scope
+
 - InnoDB transaction model vs Postgres MVCC.
 - Clustered primary key storage (vs Postgres heap).
 - Default isolation Repeatable Read (vs Postgres Read Committed).
 - Replication: async / semi-sync / group replication.
 
 ## Sub-tasks
+
 - [ ] Write a short comparison note: clustered index implications, JSON support, replication.
 - [ ] Note migration gotchas if ever moving Postgres → MySQL or vice versa.
 
 ## Concepts to know
+
 - Clustered PK means row data is physically ordered by the PK — pick it carefully.
 - InnoDB row locks use next-key locking; behavior differs from Postgres.
 - MySQL's JSON functions lag Postgres JSONB performance.
 
 ## Interview questions
+
 - Where does MySQL meaningfully differ from Postgres?
 - Clustered vs heap storage — implications for queries and writes?
 - When would you pick MySQL over Postgres today?

--- a/docs/_todo/data-storage/relational/postgresql/README.md
+++ b/docs/_todo/data-storage/relational/postgresql/README.md
@@ -3,6 +3,7 @@
 **Category:** data-storage/relational · **Primary app:** [shop-mvc-express](../../../../../workspaces/apps/shop-mvc-express/), [shop-feature-fastify](../../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Schema design, normalization (1NF–3NF), targeted denormalization.
 - Indexes: B-tree, partial, composite, covering; cost on writes.
 - Transactions and isolation levels (Read Committed, Repeatable Read, Serializable).
@@ -12,6 +13,7 @@
 - Cursor vs offset pagination.
 
 ## Sub-tasks
+
 - [ ] Design schema for `users`, `products`, `orders`, `order_items`; document 1-to-many and many-to-many.
 - [ ] Pick Drizzle or Prisma; write initial migration and seed script.
 - [ ] Add indexes `products(category_id)`, `orders(user_id, created_at)`; verify with `EXPLAIN ANALYZE`.
@@ -21,6 +23,7 @@
 - [ ] Enable `pg_stat_statements`; record a baseline of top-N slow queries.
 
 ## Concepts to know
+
 - Foreign keys + referential integrity prevent orphan rows; they also acquire locks.
 - Each index costs on every INSERT/UPDATE on that table.
 - Default isolation is Read Committed; pick Repeatable Read only when you need stable snapshots.
@@ -28,6 +31,7 @@
 - Connection count is a hard resource — pool per service, and use RDS Proxy for Lambda.
 
 ## Interview questions
+
 - Walk through the schema of your shop. Justify each index.
 - `SELECT … ORDER BY created_at DESC LIMIT 20 OFFSET 1000000` is slow — why, and how do you fix it?
 - Explain `REPEATABLE READ` vs `READ COMMITTED` with a concrete anomaly.

--- a/docs/_todo/data-storage/time-series/README.md
+++ b/docs/_todo/data-storage/time-series/README.md
@@ -3,20 +3,24 @@
 **Category:** data-storage · **Primary app:** — · **Prereqs:** postgresql · **Status:** todo
 
 ## Scope
+
 - Timescale (Postgres extension), Influx, Prometheus (short-term).
 - Downsampling / continuous aggregates.
 - Cardinality control — the common failure mode.
 
 ## Sub-tasks
+
 - [ ] Write a note on when time-series beats vanilla Postgres + `BRIN` index.
 - [ ] Sketch a downsampling schedule (1s → 1m → 1h → 1d).
 
 ## Concepts to know
+
 - Hypertables + chunks partition by time to keep inserts and range queries fast.
 - High-cardinality labels explode Prometheus; keep them bounded.
 - Retention policies drop old chunks; plan archival separately if you need history.
 
 ## Interview questions
+
 - When do you pick Timescale over vanilla Postgres?
 - Why is cardinality the enemy for metrics stores?
 - Design retention for 2 years of metrics at 1s granularity.

--- a/docs/_todo/deployment-strategies/blue-green/README.md
+++ b/docs/_todo/deployment-strategies/blue-green/README.md
@@ -3,20 +3,24 @@
 **Category:** deployment-strategies · **Primary app:** — · **Prereqs:** ecs-fargate · **Status:** todo
 
 ## Scope
+
 - Two identical environments; traffic switches instantly at the load balancer.
 - Fast rollback by flipping back.
 - DB migrations must be backward-compatible during the switch.
 
 ## Sub-tasks
+
 - [ ] Write a plan for blue-green on ECS using CodeDeploy or weighted target groups.
 - [ ] Document the DB migration contract: additive changes only during the overlap.
 
 ## Concepts to know
+
 - Cost doubles during the switch window.
 - Migrations are the real hard part — schema must satisfy both versions.
 - Smoke tests against green before flipping; rollback path tested in advance.
 
 ## Interview questions
+
 - Design a blue-green deploy for a stateful API.
 - Where does the DB migration story fit?
 - Blue-green vs canary — when each?

--- a/docs/_todo/deployment-strategies/canary/README.md
+++ b/docs/_todo/deployment-strategies/canary/README.md
@@ -3,20 +3,24 @@
 **Category:** deployment-strategies · **Primary app:** — · **Prereqs:** ecs-fargate · **Status:** todo
 
 ## Scope
+
 - Gradual traffic shift (1% → 10% → 50% → 100%).
 - Automated rollback on SLO breach (error rate, latency).
 - Requires good metrics; otherwise canary is blind.
 
 ## Sub-tasks
+
 - [ ] Document canary via CodeDeploy weighted target groups or App Mesh.
 - [ ] Define SLO-based rollback criteria in this file.
 
 ## Concepts to know
+
 - Canary matters only if you have enough traffic to detect problems at 1%.
 - Stateful changes (schema, cache format) complicate canary.
 - Feature flags are often a better knob for controlled rollout.
 
 ## Interview questions
+
 - Design canary rollout with automated rollback.
 - What metrics gate promotion?
 - How is a canary different from a feature flag?

--- a/docs/_todo/deployment-strategies/feature-flags/README.md
+++ b/docs/_todo/deployment-strategies/feature-flags/README.md
@@ -3,20 +3,24 @@
 **Category:** deployment-strategies · **Primary app:** — · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Release flags (ship dark, flip on), experiment flags (A/B), ops flags (kill switch).
 - Flag storage: config file, LaunchDarkly, Unleash, GrowthBook, Flagsmith.
 - Flag lifecycle: create → enable → clean up. Tech debt accumulates if you skip the last step.
 
 ## Sub-tasks
+
 - [ ] Pick a flag store (self-hosted or SaaS) and wire one flag into shop-feature-fastify.
 - [ ] Document the cleanup rule: every flag has a removal date or ticket.
 
 ## Concepts to know
+
 - Flags are conditional complexity in production — keep the count low.
 - Evaluating flags should be fast and cached; don't block requests on the flag service.
 - Flags are not a security boundary — never flag off sensitive checks.
 
 ## Interview questions
+
 - Design a feature-flag system. What does it need for reliability?
 - How do you prevent flag rot?
 - When does a flag go from "useful" to "tech debt"?

--- a/docs/_todo/devops-ci-cd/docker/README.md
+++ b/docs/_todo/devops-ci-cd/docker/README.md
@@ -3,6 +3,7 @@
 **Category:** devops-ci-cd · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Multi-stage builds; builder + runtime images.
 - Slim base images (distroless, `node:*-slim`) and non-root user.
 - Layer caching; lockfile-first to maximize cache hits.
@@ -11,6 +12,7 @@
 - Security: no secrets in layers, pin versions, scan with Trivy.
 
 ## Sub-tasks
+
 - [ ] Write a multi-stage Dockerfile for shop-mvc-express (build stage + runtime).
 - [ ] Run as non-root; drop Linux capabilities where possible.
 - [ ] Author `docker-compose.yml` with Postgres + Redis + app for local dev.
@@ -19,6 +21,7 @@
 - [ ] Scan the image with Trivy in CI; fail on HIGH severity.
 
 ## Concepts to know
+
 - Reorder Dockerfile so lockfile + deps land before app source — cache wins.
 - `CMD` vs `ENTRYPOINT`; signal forwarding for graceful shutdown (use `tini` or exec form).
 - Healthchecks: Docker-level only helps docker-compose; for ECS use the task definition.
@@ -26,6 +29,7 @@
 - Single-host deploys are useful for learning; ECS takes over once you need managed rollout and scaling.
 
 ## Interview questions
+
 - Walk through your multi-stage Dockerfile.
 - Why run as non-root? How do you make it work with bind mounts?
 - Why is the order of `COPY` statements load-bearing?

--- a/docs/_todo/devops-ci-cd/git-strategies/README.md
+++ b/docs/_todo/devops-ci-cd/git-strategies/README.md
@@ -3,21 +3,25 @@
 **Category:** devops-ci-cd · **Primary app:** — · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Trunk-based development with short-lived branches.
 - Git Flow (legacy; rarely worth it now).
 - Release strategies: merge queues, semver, changelogs (e.g. Changesets).
 - Commit hygiene: atomic commits, conventional commits.
 
 ## Sub-tasks
+
 - [ ] Adopt trunk-based: every branch merges to `main` via PR; no long-lived develop branch.
 - [ ] Write the branch naming + PR rules in this file.
 
 ## Concepts to know
+
 - Short-lived branches keep rebase pain low.
 - Merge queue serializes merges; reduces broken-main incidents.
 - Conventional commits enable automated changelogs and semver bumps.
 
 ## Interview questions
+
 - Trunk-based vs GitFlow — why does trunk-based win for most teams?
 - How do you prevent broken main?
 - Design releases for a library vs a service.

--- a/docs/_todo/devops-ci-cd/github-actions/README.md
+++ b/docs/_todo/devops-ci-cd/github-actions/README.md
@@ -3,6 +3,7 @@
 **Category:** devops-ci-cd · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** docker · **Status:** partial
 
 ## Scope
+
 - PR pipeline: lint, format check, typecheck, test, build.
 - Path filters to run per-app jobs only when that app changed.
 - OIDC federation for AWS deploy without static keys.
@@ -10,6 +11,7 @@
 - Security: Gitleaks, Trivy, `audit-ci --high`, SonarCloud.
 
 ## Sub-tasks
+
 - [ ] Keep the current root-level CI job (lint, format, typecheck, test).
 - [ ] Add a path-filtered build job per app under `workspaces/apps/*`.
 - [ ] Wire OIDC → IAM role for ECR push + ECS deploy.
@@ -17,12 +19,14 @@
 - [ ] Fail CI on HIGH severity from `audit-ci` or Trivy.
 
 ## Concepts to know
+
 - Use `pull_request` + `push` on main; avoid `workflow_dispatch` as the only trigger.
 - Matrix builds for Node version testing.
 - Secrets are masked in logs but not in artifacts — be careful.
 - Reusable workflows (`workflow_call`) beat copy-paste across apps.
 
 ## Interview questions
+
 - Design a CI pipeline for a monorepo with 5 apps.
 - How do you deploy to AWS without storing access keys in GitHub?
 - PR from a fork needs secrets — how do you handle that safely?

--- a/docs/_todo/devops-ci-cd/kubernetes/README.md
+++ b/docs/_todo/devops-ci-cd/kubernetes/README.md
@@ -3,6 +3,7 @@
 **Category:** devops-ci-cd · **Primary app:** — · **Prereqs:** docker · **Status:** todo
 
 ## Scope
+
 - Pods, Deployments, Services, Ingress.
 - ConfigMaps, Secrets, ServiceAccounts + IRSA on EKS.
 - HPA, PDB, resource requests/limits.
@@ -10,17 +11,20 @@
 - Operators for stateful workloads.
 
 ## Sub-tasks
+
 - [ ] Port one shop service to a local kind cluster; author a minimal Helm chart.
 - [ ] Add liveness + readiness probes that match the app's `/health` and `/readiness`.
 - [ ] Document when EKS earns its complexity vs ECS Fargate.
 
 ## Concepts to know
+
 - Requests drive scheduling; limits enforce at runtime.
 - Readiness failures remove the pod from the Service; liveness failures kill it.
 - IRSA binds a K8s ServiceAccount to an IAM role without static keys.
 - PDBs prevent all replicas from being evicted simultaneously.
 
 ## Interview questions
+
 - Kubernetes vs ECS Fargate — decision framework.
 - Explain requests vs limits and what happens when each is exceeded.
 - How does IRSA work on EKS?

--- a/docs/_todo/devops-ci-cd/terraform-iac/README.md
+++ b/docs/_todo/devops-ci-cd/terraform-iac/README.md
@@ -3,23 +3,27 @@
 **Category:** devops-ci-cd · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** aws · **Status:** todo
 
 ## Scope
+
 - Terraform state management (remote S3 + DynamoDB lock).
 - CDK as code-first alternative; compiled to CloudFormation.
 - Drift detection and remediation.
 - Environment separation: workspaces, stacks, accounts.
 
 ## Sub-tasks
+
 - [ ] Pick CDK for shop-feature-fastify; stand up the stack described in [../../cloud-services/aws/](../../cloud-services/aws/).
 - [ ] Wire CDK deploy into GitHub Actions using OIDC.
 - [ ] Document the environment strategy (dev / staging / prod account isolation).
 
 ## Concepts to know
+
 - Never edit resources in the console if IaC manages them — drift.
 - State file contains secrets; protect access.
 - Small changes beat one-shot rewrites; keep plans readable.
 - CDK escapes with `CfnResource` when L2 constructs don't support something.
 
 ## Interview questions
+
 - Terraform vs CDK — decision framework.
 - How do you handle secrets in Terraform state?
 - Someone hotfixed prod in the console. How do you detect and recover?

--- a/docs/_todo/frameworks/deno-fresh/README.md
+++ b/docs/_todo/frameworks/deno-fresh/README.md
@@ -3,19 +3,23 @@
 **Category:** frameworks · **Primary app:** — · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Deno runtime model vs Node: permissions, web-first APIs, built-in TS.
 - Fresh / Hono / Oak — what server-side Deno looks like.
 - When to consider Deno for new services (edge-first, isolates, KV).
 
 ## Sub-tasks
+
 - [ ] Read the current Deno permissions model; note implications for servers.
 - [ ] Write a 1-page Node-vs-Deno comparison focused on backend concerns.
 
 ## Concepts to know
+
 - Deno's permissions are opt-in at process level (`--allow-net`, etc.).
 - ESM-only, no `node_modules`; URL or JSR imports.
 - Runs on isolate-based platforms (Deno Deploy, Cloudflare) with different cold-start profile.
 
 ## Interview questions
+
 - Where does Deno meaningfully differ from Node?
 - Would you pick Deno for a new service today? Under what conditions?

--- a/docs/_todo/frameworks/express/README.md
+++ b/docs/_todo/frameworks/express/README.md
@@ -3,12 +3,14 @@
 **Category:** frameworks · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** event-loop · **Status:** partial
 
 ## Scope
+
 - Express 5 request lifecycle: router → middleware chain → route handler → error handler.
 - Middleware signature `(req, res, next)` and `(err, req, res, next)` for error handlers.
 - Central error translation through [HttpError](../../../../workspaces/packages/errors/) + content-negotiated HTML/JSON responses.
 - Async route wrappers so thrown errors reach the error middleware.
 
 ## Sub-tasks
+
 - [ ] Audit current [src/middleware/](../../../../workspaces/apps/shop-mvc-express/src/middleware/) for order correctness (parsers → auth → routes → error).
 - [ ] Add a request-ID middleware; attach to `req.id` and include in every log line.
 - [ ] Wrap all async route handlers with [wrapAsync](../../../../workspaces/apps/shop-mvc-express/src/utils/wrapAsync.ts) (or `express-async-errors`).
@@ -16,6 +18,7 @@
 - [ ] Document the final middleware chain in this file once stable.
 
 ## Concepts to know
+
 - Order matters: body parsers, cookie parser, auth, routes, 404, error.
 - Why error middleware needs 4 args to be recognized.
 - Express 5 auto-catches rejected promises from route handlers (5.x behavior change).
@@ -23,6 +26,7 @@
 - Graceful shutdown: `server.close()` + in-flight drain.
 
 ## Interview questions
+
 - Explain middleware in Express. What order do you register them in and why?
 - How does Express 5 differ from 4 for async error handling?
 - How does your error middleware know whether to render HTML or JSON?

--- a/docs/_todo/frameworks/fastify/README.md
+++ b/docs/_todo/frameworks/fastify/README.md
@@ -3,12 +3,14 @@
 **Category:** frameworks · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** express · **Status:** todo
 
 ## Scope
+
 - Fastify plugin system: encapsulation, lifecycle hooks, `fastify.register`.
 - Type providers (Zod or TypeBox) for compile-time + runtime validation.
 - Per-feature plugins exporting their own route + schema + service.
 - Built-in JSON schema compilation for performance.
 
 ## Sub-tasks
+
 - [ ] Scaffold the app using [@workspaces/packages/config](../../../../workspaces/packages/config/) and the esbuild workspace onResolve plugin.
 - [ ] Wire `fastify-type-provider-zod` and generate OpenAPI from route schemas.
 - [ ] Create `src/modules/{products,users,orders,cart}`; each a Fastify plugin.
@@ -16,12 +18,14 @@
 - [ ] Integrate Pino with request IDs; propagate to services via `onRequest` hook.
 
 ## Concepts to know
+
 - Plugin encapsulation: child plugin decorators do not leak to parent.
 - Lifecycle hooks: `onRequest`, `preHandler`, `preSerialization`, `onSend`, `onResponse`, `onError`.
 - Performance: Fastify's JSON schema compile outpaces Express + manual validation.
 - Graceful shutdown via `fastify.close()`.
 
 ## Interview questions
+
 - Why did you pick Fastify over Express for v2 of the shop?
 - Explain Fastify plugin encapsulation and when it bites you.
 - How does type-provider Zod differ from validating inside controllers?

--- a/docs/_todo/frameworks/nestjs/README.md
+++ b/docs/_todo/frameworks/nestjs/README.md
@@ -3,22 +3,26 @@
 **Category:** frameworks · **Primary app:** — · **Prereqs:** fastify · **Status:** todo
 
 ## Scope
+
 - Module system, providers, and the DI container.
 - Decorators-driven controllers + guards + interceptors + pipes.
 - Running on Express or Fastify HTTP adapters.
 - When Nest's opinionated structure earns its cost vs vanilla Fastify.
 
 ## Sub-tasks
+
 - [ ] Re-implement one shop module (e.g. products) in Nest for direct comparison.
 - [ ] Compare bundle size, cold-start time, and LOC against the Fastify version.
 - [ ] Document the decision framework: when Nest, when not.
 
 ## Concepts to know
+
 - Module providers are singletons by default; scoped/request providers cost performance.
 - Guards vs interceptors vs pipes — where each runs in the lifecycle.
 - DI graph: circular deps, `forwardRef`, and how to avoid them.
 
 ## Interview questions
+
 - When would you pick Nest over Fastify?
 - How does Nest's DI compare with manual wiring or tsyringe?
 - Explain the Nest request lifecycle: where does each decorator fire?

--- a/docs/_todo/microservices/api-gateway/README.md
+++ b/docs/_todo/microservices/api-gateway/README.md
@@ -3,24 +3,28 @@
 **Category:** microservices · **Primary app:** [bff-gateway](../../../../workspaces/apps/bff-gateway/) · **Prereqs:** rest · **Status:** todo
 
 ## Scope
+
 - API gateway responsibilities: routing, auth offload, rate limiting, request transformation.
 - BFF (Backend For Frontend) vs generic gateway.
 - Request aggregation / composition.
 - Where auth happens: edge vs service.
 
 ## Sub-tasks
+
 - [ ] Build a minimal Fastify gateway that routes `/auth/*` → auth-service, `/shop/*` → shop-feature-fastify.
 - [ ] Verify the access JWT once at the gateway; propagate claims to downstreams.
 - [ ] Implement one aggregation endpoint that composes data from both services.
 - [ ] Apply global rate limits at the gateway; per-route caps on sensitive endpoints.
 
 ## Concepts to know
+
 - Don't put business logic in the gateway — that's how it becomes a monolith again.
 - BFF per client type (web / mobile) keeps clients from dictating backend contracts.
 - Gateway adds latency — measure it.
 - Retries at the gateway can amplify backend failures.
 
 ## Interview questions
+
 - When do you need a gateway? When a plain load balancer?
 - BFF vs generic gateway — when do you split?
 - How do you avoid the gateway becoming a new monolith?

--- a/docs/_todo/microservices/event-bus-kafka/README.md
+++ b/docs/_todo/microservices/event-bus-kafka/README.md
@@ -3,22 +3,26 @@
 **Category:** microservices · **Primary app:** — · **Prereqs:** event-driven · **Status:** todo
 
 ## Scope
+
 - Kafka topics, partitions, consumer groups, offsets.
 - Delivery semantics: at-least-once default; exactly-once with idempotent producer + transactions (within Kafka only).
 - SNS fan-out + SQS consumer queues as a simpler AWS-native alternative.
 - When managed (MSK / Confluent) beats self-hosted.
 
 ## Sub-tasks
+
 - [ ] Write a short note comparing Kafka vs SNS+SQS vs EventBridge for shop + orders events.
 - [ ] Sketch partitioning for a `orders.events` topic (partition key choice, ordering guarantees).
 
 ## Concepts to know
+
 - Partition = unit of parallelism and ordering. Pick the key carefully.
 - Consumer group rebalancing stalls consumption briefly — design for it.
 - Retention is time-based by default; compact topics for "latest value per key".
 - Backpressure: slow consumers lag; monitor lag, alert before it hits retention.
 
 ## Interview questions
+
 - Kafka vs SNS+SQS — decision framework.
 - What does a partition key give you, and how do you pick one for orders?
 - Explain consumer group rebalancing and why it causes latency spikes.

--- a/docs/_todo/microservices/idempotency-retries/README.md
+++ b/docs/_todo/microservices/idempotency-retries/README.md
@@ -3,12 +3,14 @@
 **Category:** microservices · **Primary app:** [orders-event-driven](../../../../workspaces/apps/orders-event-driven/) · **Prereqs:** event-driven · **Status:** todo
 
 ## Scope
+
 - Idempotency keys on unsafe writes (orders, payments).
 - Outbox pattern to solve the dual-write problem (DB write + publish).
 - Retries with exponential backoff and jitter.
 - Dead-letter queues for poison messages; replay tooling.
 
 ## Sub-tasks
+
 - [ ] Add idempotency-key header support on `POST /orders`; dedupe on the key within TTL.
 - [ ] Implement the outbox pattern in the `orders` service: write event rows in the same DB tx as the order.
 - [ ] Build a relay that reads outbox rows and publishes them at-least-once.
@@ -16,12 +18,14 @@
 - [ ] Configure an SQS DLQ for the consumer; alert on depth > 0.
 
 ## Concepts to know
+
 - "Exactly-once" end-to-end is only achievable via idempotent consumers, not via the bus.
 - Outbox trades storage + a relay for atomicity between DB state and event publish.
 - Retry without jitter creates thundering herds.
 - Replaying a DLQ needs the handler to still be idempotent.
 
 ## Interview questions
+
 - Explain the dual-write problem and how the outbox pattern solves it.
 - Client retries a payment POST — how do you prevent double-charging?
 - A poison message is stuck in your SQS consumer. How do you protect throughput?

--- a/docs/_todo/microservices/saga-pattern/README.md
+++ b/docs/_todo/microservices/saga-pattern/README.md
@@ -3,24 +3,28 @@
 **Category:** microservices · **Primary app:** [orders-event-driven](../../../../workspaces/apps/orders-event-driven/) · **Prereqs:** idempotency-retries · **Status:** todo
 
 ## Scope
+
 - Orchestration (central coordinator) vs choreography (services react to events).
 - Compensating actions for each step.
 - Timeouts and retries at the saga level.
 - State persistence for the coordinator.
 
 ## Sub-tasks
+
 - [ ] Design the order saga: reserve stock → charge payment → confirm order; with compensations.
 - [ ] Implement a saga coordinator (single service) that persists state per saga id.
 - [ ] Emit compensation events on failure: cancel order, release stock, refund payment.
 - [ ] Write a doc listing every failure mode and the corresponding compensation.
 
 ## Concepts to know
+
 - Sagas replace distributed transactions; consistency is eventual.
 - Compensation is not always possible — some actions are irreversible (email sent). Plan around them.
 - Choreography scales org-wise but obscures flow; orchestration centralizes flow but couples to a service.
 - Idempotency on every step is non-negotiable.
 
 ## Interview questions
+
 - Orchestration vs choreography — when each?
 - Saga for an order that reserves stock, charges payment, emails the user — what compensates what?
 - A compensating step fails. Now what?

--- a/docs/_todo/microservices/service-discovery/README.md
+++ b/docs/_todo/microservices/service-discovery/README.md
@@ -3,21 +3,25 @@
 **Category:** microservices · **Primary app:** — · **Prereqs:** microservices · **Status:** todo
 
 ## Scope
+
 - DNS-based (ECS Service Connect, Kubernetes DNS, Consul DNS).
 - Registry-based (Consul, etcd, Zookeeper).
 - Client-side vs server-side discovery.
 - Health checks that drive discovery.
 
 ## Sub-tasks
+
 - [ ] Note which ECS Service Connect features cover discovery + load balancing natively.
 - [ ] Write a short comparison vs manual ALB target groups.
 
 ## Concepts to know
+
 - DNS TTLs can lag; health checks need to remove bad nodes fast.
 - Mesh (Envoy sidecar) can take discovery + retries off the app.
 - For N<10 services, a static config or load balancer URL is often enough.
 
 ## Interview questions
+
 - When do you need service discovery beyond DNS + a load balancer?
 - Client-side vs server-side discovery — trade-offs?
 - How does a mesh change the discovery story?

--- a/docs/_todo/observability/alerting-grafana/README.md
+++ b/docs/_todo/observability/alerting-grafana/README.md
@@ -3,23 +3,27 @@
 **Category:** observability · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** metrics · **Status:** todo
 
 ## Scope
+
 - SLO-based alerting (burn-rate alerts).
 - CloudWatch alarms on ECS / ALB / RDS.
 - Alert routing: PagerDuty / OpsGenie / email.
 - Runbook links in every alert.
 
 ## Sub-tasks
+
 - [ ] Add CloudWatch alarms: 5xx rate, p95 latency, ECS task restart rate, RDS CPU, Redis memory.
 - [ ] Write a runbook per alert in this file (or link to an app ARCHITECTURE.md).
 - [ ] Define a burn-rate alert for the SLO defined in [../metrics-prometheus/](../metrics-prometheus/).
 
 ## Concepts to know
+
 - Symptom-based alerts (users affected) beat cause-based alerts (CPU high).
 - Burn-rate alerts are fast + slow — fast catches outages, slow catches leaks.
 - Every alert must be actionable, or it rots into noise.
 - Paging at 3 AM for an auto-recoverable blip is a bug in the alert.
 
 ## Interview questions
+
 - What's a good alert? What's a bad one?
 - Explain SLO burn rate and design an alert pair.
 - An alert fires every week and nobody acts on it. Fix the system, not the person.

--- a/docs/_todo/observability/logging/README.md
+++ b/docs/_todo/observability/logging/README.md
@@ -3,12 +3,14 @@
 **Category:** observability · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** express · **Status:** todo
 
 ## Scope
+
 - Pino structured JSON logs; log levels; child loggers.
 - Request-ID middleware and trace-ID propagation.
 - Log hygiene: no PII, no secrets, reasonable cardinality.
 - Sink: stdout in prod; container runtime ships it.
 
 ## Sub-tasks
+
 - [ ] Wire Pino in shop-mvc-express; emit JSON at info in prod, pretty in dev.
 - [ ] Add a request-ID middleware; attach to `req.id` and include in every log line.
 - [ ] Create a child logger per request via `req.log` for scoped fields.
@@ -16,12 +18,14 @@
 - [ ] Confirm logs reach CloudWatch Logs when deployed.
 
 ## Concepts to know
+
 - Structured logs let you query by field; plain text doesn't.
 - `pino-pretty` is dev-only; ship JSON.
 - Never log passwords, tokens, PANs, or full JWTs.
 - Keep log keys stable — your queries depend on them.
 
 ## Interview questions
+
 - Why structured logs? Give a query you can run against JSON that you can't against text.
 - What's a request ID vs a trace ID?
 - Your logs are 10x what they were last week. How do you diagnose and cut cost?

--- a/docs/_todo/observability/metrics-prometheus/README.md
+++ b/docs/_todo/observability/metrics-prometheus/README.md
@@ -3,6 +3,7 @@
 **Category:** observability · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** logging · **Status:** todo
 
 ## Scope
+
 - RED (Rate, Errors, Duration) for services; USE (Utilization, Saturation, Errors) for resources.
 - Counter vs Gauge vs Histogram vs Summary.
 - Cardinality: every label multiplies series count.
@@ -10,18 +11,21 @@
 - SLIs / SLOs / error budgets.
 
 ## Sub-tasks
+
 - [ ] Add `prom-client` to shop-feature-fastify; expose `/metrics`.
 - [ ] Emit `http_request_duration_seconds` histogram, labeled `route`, `method`, `status`.
 - [ ] Emit a `cache_hit_ratio` gauge for the Redis cache-aside layer.
 - [ ] Set one SLO per app (e.g. 99.5% success on /products, p95 < 200ms); document in this file.
 
 ## Concepts to know
+
 - Histograms let you compute percentiles; summaries pre-compute but can't aggregate.
 - High-cardinality labels (user_id, URL path) blow up the series count.
 - Alert on SLO burn, not on raw values.
 - Exemplars tie a histogram bucket to a trace ID — debug gold.
 
 ## Interview questions
+
 - RED vs USE — when each?
 - Why do high-cardinality labels kill Prometheus?
 - Pick three metrics for a REST service and justify them.

--- a/docs/_todo/observability/tracing-opentelemetry/README.md
+++ b/docs/_todo/observability/tracing-opentelemetry/README.md
@@ -3,6 +3,7 @@
 **Category:** observability · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** logging · **Status:** todo
 
 ## Scope
+
 - OTel concepts: spans, context propagation, resources, exporters.
 - Auto-instrumentation for HTTP, PG, Redis.
 - Manual spans around custom work (caches, queues).
@@ -10,18 +11,21 @@
 - Sampling strategies.
 
 ## Sub-tasks
+
 - [ ] Wire `@opentelemetry/sdk-node` with auto-instrumentations in shop-feature-fastify.
 - [ ] Export to a local Jaeger in docker-compose.
 - [ ] Add a manual span around the cache-aside block with cache-hit attribute.
 - [ ] Document the sampling rate and why.
 
 ## Concepts to know
+
 - Tail-based sampling keeps slow/errored traces; head-based is cheaper but random.
 - Never log full span attributes at high volume.
 - Trace IDs are worth more than logs when debugging latency across services.
 - Exemplars (metric ↔ trace link) close the three-pillar loop.
 
 ## Interview questions
+
 - Explain a trace, a span, and baggage.
 - How do traces propagate across services? What headers?
 - Head vs tail sampling — when each?

--- a/docs/_todo/performance-optimization/benchmarking-autocannon/README.md
+++ b/docs/_todo/performance-optimization/benchmarking-autocannon/README.md
@@ -3,23 +3,27 @@
 **Category:** performance-optimization · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - `autocannon` for quick Node-native load.
 - `k6` for scripted scenarios and CI integration.
 - Steady-state vs spike vs soak tests.
 - Interpreting p95 / p99, not just averages.
 
 ## Sub-tasks
+
 - [ ] Benchmark `GET /products` before/after Redis cache with autocannon; record numbers.
 - [ ] Add a k6 scenario that ramps from 10 → 500 RPS.
 - [ ] Document the warm-up period + sample window in every benchmark.
 
 ## Concepts to know
+
 - Don't benchmark from the same box as the server — you compete for CPU.
 - Warm-up matters: JIT, pools, caches.
 - Percentiles tell the truth that averages hide.
 - Compare apples to apples: same payload size, same auth, same DB state.
 
 ## Interview questions
+
 - Why p95/p99 over mean?
 - How do you make a benchmark reproducible?
 - Your benchmark shows 100K RPS but prod crumbles at 10K. What went wrong?

--- a/docs/_todo/performance-optimization/memory-leaks/README.md
+++ b/docs/_todo/performance-optimization/memory-leaks/README.md
@@ -3,22 +3,26 @@
 **Category:** performance-optimization · **Primary app:** — · **Prereqs:** profiling · **Status:** todo
 
 ## Scope
+
 - Heap snapshots (`--heapsnapshot-signal=SIGUSR2`, Chrome DevTools).
 - Retainers: closures, timers, event listeners, caches without bounds.
 - `--inspect` + `heapdump` module.
 - Detecting: growing RSS, growing retained size across snapshots.
 
 ## Sub-tasks
+
 - [ ] Induce a small leak in a demo app; walk through locating it with heap snapshots.
 - [ ] Document the Three Snapshots technique (baseline → load → load again) here.
 
 ## Concepts to know
+
 - RSS growth ≠ always a leak; GC may be lazy.
 - Closures capture their enclosing scope entirely — be careful with large contexts.
 - Unbounded caches and registries are the top cause.
 - Timers + listeners outlive the objects that registered them unless cleaned up.
 
 ## Interview questions
+
 - Your Node process RSS grows 100MB/day. Walk through diagnosis.
 - What's the Three Snapshots technique?
 - Why is `setInterval` a common leak source?

--- a/docs/_todo/performance-optimization/profiling/README.md
+++ b/docs/_todo/performance-optimization/profiling/README.md
@@ -3,22 +3,26 @@
 **Category:** performance-optimization · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** event-loop · **Status:** todo
 
 ## Scope
+
 - V8 profiler (`--prof`, `--cpu-prof`).
 - `clinic.js` toolkit: doctor, flame, bubbleprof.
 - Inspector + Chrome DevTools CPU profile.
 - Flame graphs — reading them.
 
 ## Sub-tasks
+
 - [ ] Profile one hot path in shop-feature-fastify with `clinic doctor`.
 - [ ] Capture a flame graph of the product list endpoint under load.
 - [ ] Record a before/after in this file with the root cause and fix.
 
 ## Concepts to know
+
 - Profile in a prod-like env — dev overhead can dominate signal.
 - Self-time vs total-time — know which column to read for what.
 - Tickets for the event loop vs I/O wait look very different in flames.
 
 ## Interview questions
+
 - Walk me through finding a CPU bottleneck with `clinic`.
 - How do you profile a service you can't run locally?
 - How do you confirm a fix is actually a fix?

--- a/docs/_todo/performance-optimization/scalability-patterns/README.md
+++ b/docs/_todo/performance-optimization/scalability-patterns/README.md
@@ -3,6 +3,7 @@
 **Category:** performance-optimization · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) · **Prereqs:** ecs-fargate · **Status:** todo
 
 ## Scope
+
 - Horizontal scaling (HPA / ECS service auto-scaling) on CPU, memory, RPS.
 - Read replicas for read-heavy workloads.
 - Sharding and partitioning.
@@ -10,18 +11,21 @@
 - Caching layers (see [../../data-storage/caching/redis/](../../data-storage/caching/redis/)).
 
 ## Sub-tasks
+
 - [ ] Configure ECS auto-scaling on CPU + ALB request-count-per-target for shop-feature-fastify.
 - [ ] Sketch a read-replica strategy for product queries; route reads via env-configured replica URL.
 - [ ] Benchmark before/after adding a second ECS task (scale-out) using autocannon.
 - [ ] Document the Black Friday game plan: what scales first, second, last.
 
 ## Concepts to know
+
 - Stateless services are trivial to scale horizontally; state is the blocker.
 - Database is usually the first real bottleneck.
 - Auto-scaling takes minutes; plan for steady state + spikes differently.
 - Caching + async offload often beat throwing more instances.
 
 ## Interview questions
+
 - 10x traffic spike — what breaks first in your stack?
 - Sharding vs read replicas vs caching — decision framework.
 - Design auto-scaling signals for a spiky workload.

--- a/docs/_todo/testing-quality/contract-testing/README.md
+++ b/docs/_todo/testing-quality/contract-testing/README.md
@@ -3,22 +3,26 @@
 **Category:** testing-quality · **Primary app:** [shop-feature-fastify](../../../../workspaces/apps/shop-feature-fastify/) ↔ [auth-service](../../../../workspaces/apps/auth-service/) · **Prereqs:** integration-testing · **Status:** todo
 
 ## Scope
+
 - Consumer-driven contracts (Pact).
 - Provider verification against captured contracts.
 - Broker: Pactflow / self-hosted.
 - When to skip: single-team monorepo often doesn't need it.
 
 ## Sub-tasks
+
 - [ ] Set up a Pact contract between shop-feature-fastify (consumer) and auth-service (provider).
 - [ ] Run consumer tests in PR; run provider verification before auth-service deploys.
 - [ ] Document the rollout story: break-glass when contracts intentionally change.
 
 ## Concepts to know
+
 - Contracts are specs for what the consumer needs, not what the provider offers.
 - Provider changes that break the contract fail CI before deploy.
 - Contracts rot without enforcement — tie them to deploy.
 
 ## Interview questions
+
 - When does contract testing earn its keep?
 - Explain consumer-driven contracts vs schema-first APIs.
 - A contract fails after a provider deploy. Walk me through resolving.

--- a/docs/_todo/testing-quality/integration-testing/README.md
+++ b/docs/_todo/testing-quality/integration-testing/README.md
@@ -3,23 +3,27 @@
 **Category:** testing-quality · **Primary app:** [shop-mvc-express](../../../../workspaces/apps/shop-mvc-express/) · **Prereqs:** unit-testing · **Status:** todo
 
 ## Scope
+
 - Real DB tests (Postgres via Testcontainers or docker-compose).
 - Supertest for HTTP-level assertions.
 - Isolation: per-test transaction rollback or schema reset.
 - Fixtures and factories.
 
 ## Sub-tasks
+
 - [ ] Wire Testcontainers Postgres into shop-mvc-express test suite.
 - [ ] Supertest the full request → handler → DB → response path for products.
 - [ ] Run integration tests in CI on push to main; keep unit tests on every PR.
 - [ ] Document test data strategy in this file.
 
 ## Concepts to know
+
 - Real DB tests catch migration and query bugs unit tests miss.
 - Slow tests destroy feedback loops — keep integration to the critical paths.
 - Shared mutable DB state is a flake generator.
 
 ## Interview questions
+
 - Unit vs integration — where do you draw the line?
 - How do you isolate state between integration tests?
 - When do you hit an HTTP endpoint vs call the controller directly?

--- a/docs/_todo/testing-quality/mutation-testing/README.md
+++ b/docs/_todo/testing-quality/mutation-testing/README.md
@@ -3,20 +3,24 @@
 **Category:** testing-quality · **Primary app:** — · **Prereqs:** unit-testing · **Status:** todo
 
 ## Scope
+
 - Stryker introduces small code changes; surviving mutants mean weak tests.
 - Mutation score as a complement to line coverage.
 - Cost: slow; run in nightly or weekly CI.
 
 ## Sub-tasks
+
 - [ ] Run Stryker once against a service layer; record mutation score here.
 - [ ] Strengthen the three weakest tests based on surviving mutants.
 
 ## Concepts to know
+
 - 100% line coverage can still leave branches untested — mutation catches that.
 - Not every surviving mutant is a real bug — equivalent mutants exist.
 - Run on changed files only in PR to keep feedback fast.
 
 ## Interview questions
+
 - What does mutation testing find that line coverage misses?
 - When is Stryker worth the CI time?
 - What's an equivalent mutant and how do you handle it?

--- a/docs/_todo/testing-quality/static-analysis/README.md
+++ b/docs/_todo/testing-quality/static-analysis/README.md
@@ -3,23 +3,27 @@
 **Category:** testing-quality · **Primary app:** all · **Prereqs:** — · **Status:** partial
 
 ## Scope
+
 - ESLint flat config with `recommendedTypeChecked` + `stylisticTypeChecked` + `projectService`.
 - Prettier for formatting; no bikeshedding.
 - SonarCloud for cross-PR quality gates + security.
 - `audit-ci --high` for dep vulnerabilities; Gitleaks + Trivy.
 
 ## Sub-tasks
+
 - [ ] Keep the current ESLint flat config in [../../../../eslint.config.mjs](../../../../eslint.config.mjs).
 - [ ] Ensure every new tsconfig is picked up by `projectService: true`.
 - [ ] Add SonarCloud quality gate to CI; document thresholds here.
 - [ ] Keep typed rules strict; don't relax them outside `**/*.{test,spec}.*`.
 
 ## Concepts to know
+
 - Typed-lint rules require typecheck to run — slower but much stronger.
 - `verbatimModuleSyntax` forces `import type` for types; enforced by `consistent-type-imports`.
 - `perfectionist/sort-*` rules auto-fix import groups and object key order on `pnpm lint:fix`.
 
 ## Interview questions
+
 - Why typed ESLint rules vs syntactic?
 - How do you keep a static-analysis config from drifting across a monorepo?
 - What static checks belong at pre-commit vs CI vs scheduled?

--- a/docs/_todo/testing-quality/unit-testing-jest/README.md
+++ b/docs/_todo/testing-quality/unit-testing-jest/README.md
@@ -3,22 +3,26 @@
 **Category:** testing-quality · **Primary app:** all · **Prereqs:** — · **Status:** todo
 
 ## Scope
+
 - Vitest (already in local-llm-playground) for fast ESM-native testing.
 - Arrange-Act-Assert structure; one behavior per test.
 - Mocking only external dependencies at the seam (repositories, HTTP clients).
 - Snapshot testing — use sparingly.
 
 ## Sub-tasks
+
 - [ ] Add Vitest unit tests for each service in shop-feature-fastify; mock only repositories.
 - [ ] Target 80%+ coverage for services; don't chase 100%.
-- [ ] Write a note on what *not* to unit-test (framework glue, trivial getters).
+- [ ] Write a note on what _not_ to unit-test (framework glue, trivial getters).
 
 ## Concepts to know
+
 - Don't mock what you own — hide real implementations behind interfaces and swap those.
 - Tests are specs; name them by behavior.
 - Fast feedback matters more than cleverness. Keep tests dumb.
 
 ## Interview questions
+
 - When does a unit test have value? When doesn't it?
 - What do you mock? What don't you?
 - Snapshot tests — when do they earn their keep?

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "pnpm -r --filter ./workspaces/apps/*... run build",
+    "build": "pnpm -r run --if-present build",
     "typecheck": "pnpm -r run --if-present typecheck",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,28 @@ importers:
         specifier: ^8.58.1
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
+  workspaces/ai-engineering/llm-chat:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.92.0
+        version: 0.92.0(zod@4.1.12)
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))
+
   workspaces/apps/local-llm-playground:
     dependencies:
       dotenv:
@@ -178,8 +200,21 @@ importers:
 
 packages:
 
+  '@anthropic-ai/sdk@0.92.0':
+    resolution: {integrity: sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.9.1':
@@ -847,6 +882,9 @@ packages:
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
@@ -945,8 +983,22 @@ packages:
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
   '@vitest/mocker@4.1.4':
     resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -959,17 +1011,32 @@ packages:
   '@vitest/pretty-format@4.1.4':
     resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
   '@vitest/runner@4.1.4':
     resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
 
   '@vitest/snapshot@4.1.4':
     resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
   '@vitest/spy@4.1.4':
     resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1598,6 +1665,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2103,6 +2174,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2151,6 +2225,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2260,6 +2337,47 @@ packages:
       jsdom:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -2328,7 +2446,15 @@ packages:
 
 snapshots:
 
+  '@anthropic-ai/sdk@0.92.0(zod@4.1.12)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.1.12
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
 
   '@emnapi/core@1.9.1':
     dependencies:
@@ -2751,7 +2877,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.9.2
+      '@types/node': 25.6.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2760,7 +2886,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.9.2
+      '@types/node': 25.6.0
 
   '@types/deep-eql@4.0.2': {}
 
@@ -2770,7 +2896,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.0':
     dependencies:
-      '@types/node': 24.9.2
+      '@types/node': 25.6.0
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -2795,6 +2921,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -2810,16 +2940,16 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.9.2
+      '@types/node': 25.6.0
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 24.9.2
+      '@types/node': 25.6.0
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.9.2
+      '@types/node': 25.6.0
       '@types/send': 0.17.6
 
   '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
@@ -2927,6 +3057,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@4.1.4(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -2935,13 +3074,30 @@ snapshots:
     optionalDependencies:
       vite: 8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.5(vite@8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
+
   '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
 
   '@vitest/runner@4.1.4':
     dependencies:
       '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.4':
@@ -2951,11 +3107,26 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@4.1.4': {}
+
+  '@vitest/spy@4.1.5': {}
 
   '@vitest/utils@4.1.4':
     dependencies:
       '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -3645,6 +3816,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -4111,6 +4287,8 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  ts-algebra@2.0.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -4158,6 +4336,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici-types@7.19.2: {}
+
   unpipe@1.0.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
@@ -4191,6 +4371,21 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.3
 
+  vite@8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.13
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.20.6
+      yaml: 2.8.3
+
   vitest@4.1.4(@types/node@25.5.2)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
@@ -4215,6 +4410,33 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - workspaces/apps/*
+  - workspaces/ai-engineering/*
   - workspaces/packages/*
 
 ignoredBuiltDependencies:

--- a/workspaces/ai-engineering/README.md
+++ b/workspaces/ai-engineering/README.md
@@ -1,0 +1,9 @@
+# AI Engineering
+
+Small runnable examples for learning Claude API, MCP, Claude Code workflows, and related AI engineering patterns.
+
+Start with [llm-chat](./llm-chat/), a minimal LLM chat example with an Anthropic provider adapter.
+
+## Examples
+
+- [llm-chat](./llm-chat/) - provider-neutral LLM chat CLI with an Anthropic adapter and room to add multi-turn history, streaming, tools, and evals.

--- a/workspaces/ai-engineering/llm-chat/.gitignore
+++ b/workspaces/ai-engineering/llm-chat/.gitignore
@@ -1,0 +1,7 @@
+**/.env
+node_modules/
+dist/
+coverage/
+.env
+.env.*
+!.env.example

--- a/workspaces/ai-engineering/llm-chat/README.md
+++ b/workspaces/ai-engineering/llm-chat/README.md
@@ -1,0 +1,60 @@
+# LLM Chat
+
+Minimal Node.js/TypeScript LLM chat CLI. Currently ships an Anthropic provider; the structure is provider-neutral so other LLMs, tool use, RAG, evals, or MCP can be added later without a rewrite.
+
+Assistant responses stream by default in the CLI.
+
+Use `--output-format=json`, `--output-format=csv`, or `--output-format=html`
+when you want formatted output on demand. `--structured-commands` is an alias
+for `--output-format=json`.
+
+The `json` format uses Anthropic native structured outputs (`output_config.format`)
+so it works correctly on Claude 4.6+ without requiring assistant message prefill.
+The `csv` and `html` formats use instruction-only formatting.
+
+## Run
+
+Create `.env` in this folder:
+
+```env
+ANTHROPIC_API_KEY="your-api-key-here"
+# Optional:
+ANTHROPIC_MODEL="claude-sonnet-4-20250514"
+```
+
+Install dependencies from the repository root:
+
+```bash
+pnpm install
+```
+
+Run the interactive chat app from this folder:
+
+```bash
+pnpm dev
+```
+
+Or from the repository root:
+
+```bash
+pnpm --filter llm-chat dev
+```
+
+Formatted output from the repository root:
+
+```bash
+pnpm --filter llm-chat dev -- --output-format=json
+pnpm --filter llm-chat dev -- --output-format=csv
+pnpm --filter llm-chat dev -- --output-format=html
+```
+
+The system prompt and temperature are currently hardcoded in `src/main.ts` as `SYSTEM_PROMPT` and `TEMPERATURE`.
+
+## Source Map
+
+- `src/main.ts` - thin CLI bootstrap.
+- `src/config/env.ts` - `.env` loading, API key validation, model selection.
+- `src/cli/` - argument parsing, readline input adapter, interactive loop.
+- `src/chat/` - chat types, message history helpers, chat service that orchestrates a turn.
+- `src/llm/` - provider-neutral types and provider factory.
+- `src/llm/anthropic/` - Anthropic SDK adapter (client, messages API, response text extraction).

--- a/workspaces/ai-engineering/llm-chat/package.json
+++ b/workspaces/ai-engineering/llm-chat/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "llm-chat",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "tsx src/main.ts",
+    "start": "tsx src/main.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/workspaces/ai-engineering/llm-chat/src/chat/history.ts
+++ b/workspaces/ai-engineering/llm-chat/src/chat/history.ts
@@ -1,0 +1,9 @@
+import type { Messages } from './types.js';
+
+export function addUserMessage(messages: Messages, text: string): void {
+  messages.push({ content: text, role: 'user' });
+}
+
+export function addAssistantMessage(messages: Messages, text: string): void {
+  messages.push({ content: text, role: 'assistant' });
+}

--- a/workspaces/ai-engineering/llm-chat/src/chat/service.ts
+++ b/workspaces/ai-engineering/llm-chat/src/chat/service.ts
@@ -1,0 +1,49 @@
+import type { LlmProvider, LlmRequest } from '../llm/types.js';
+import { addAssistantMessage, addUserMessage } from './history.js';
+import type { ChatOptions, Messages } from './types.js';
+
+export const DEFAULT_MAX_TOKENS = 1000;
+export const DEFAULT_STREAM = true;
+
+export interface ChatServiceConfig {
+  readonly defaultMaxTokens?: number;
+  readonly model: string;
+  readonly provider: LlmProvider;
+  readonly systemPrompt?: string;
+  readonly temperature?: number;
+}
+
+export interface ChatService {
+  sendUserTurn(messages: Messages, text: string, options?: ChatOptions): Promise<string>;
+}
+
+export function createChatService(config: ChatServiceConfig): ChatService {
+  const defaultMaxTokens = config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+
+  return {
+    async sendUserTurn(messages, text, options = {}) {
+      addUserMessage(messages, text);
+
+      const request: LlmRequest = {
+        maxTokens: options.maxTokens ?? defaultMaxTokens,
+        messages,
+        model: config.model,
+        stream: options.stream ?? DEFAULT_STREAM,
+        ...(options.onTextDelta ? { onTextDelta: options.onTextDelta } : {}),
+        ...(options.outputFormat ? { outputFormat: options.outputFormat } : {}),
+        ...(config.systemPrompt ? { systemPrompt: config.systemPrompt } : {}),
+        ...(config.temperature === undefined ? {} : { temperature: config.temperature }),
+      };
+
+      const response = await config.provider.createMessage(request);
+
+      if (options.debugResponse) {
+        console.log('Full response:', response.raw);
+      }
+
+      addAssistantMessage(messages, response.text);
+
+      return response.text;
+    },
+  };
+}

--- a/workspaces/ai-engineering/llm-chat/src/chat/types.ts
+++ b/workspaces/ai-engineering/llm-chat/src/chat/types.ts
@@ -1,0 +1,16 @@
+import type { OutputFormatConfig, TextDeltaHandler } from '../llm/types.js';
+
+export interface ChatMessage {
+  content: string;
+  role: 'user' | 'assistant';
+}
+
+export type Messages = ChatMessage[];
+
+export interface ChatOptions {
+  debugResponse?: boolean;
+  maxTokens?: number;
+  onTextDelta?: TextDeltaHandler;
+  outputFormat?: OutputFormatConfig;
+  stream?: boolean;
+}

--- a/workspaces/ai-engineering/llm-chat/src/cli/args.ts
+++ b/workspaces/ai-engineering/llm-chat/src/cli/args.ts
@@ -1,0 +1,102 @@
+import type { ChatOptions } from '../chat/types.js';
+import type { OutputFormatConfig } from '../llm/types.js';
+
+export const OUTPUT_FORMAT_PRESETS = {
+  csv: {
+    instructions:
+      'Return the response as CSV only. Include a header row. Do not include comments, markdown fences, or explanation.',
+  },
+  html: {
+    instructions:
+      'Return the response as HTML only. Use an unordered list when listing items. Do not include comments, markdown fences, or explanation.',
+  },
+  json: {
+    instructions:
+      'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+    jsonSchema: {
+      additionalProperties: false,
+      properties: {
+        commands: {
+          items: { type: 'string' },
+          type: 'array',
+        },
+      },
+      required: ['commands'],
+      type: 'object',
+    },
+  },
+} satisfies Record<string, OutputFormatConfig>;
+
+type OutputFormatName = keyof typeof OUTPUT_FORMAT_PRESETS;
+
+function parseOutputFormat(value: string): OutputFormatConfig {
+  if (value in OUTPUT_FORMAT_PRESETS) {
+    return OUTPUT_FORMAT_PRESETS[value as OutputFormatName];
+  }
+
+  throw new Error('--output-format must be one of: json, csv, html.');
+}
+
+export interface ParsedArgs {
+  readonly options: ChatOptions;
+  readonly shouldPrintHelp: boolean;
+}
+
+export function helpText(): string {
+  return [
+    'Usage: pnpm dev [--max-tokens=<number>] [--debug-response] [--output-format=json|csv|html]',
+    '',
+    'Run the LLM chat app.',
+    '',
+    'Options:',
+    '  --max-tokens=<number>   Maximum number of output tokens per turn.',
+    '  --debug-response        Print the full provider response object.',
+    '  --output-format=<name>   Return a response formatted as json, csv, or html.',
+    '  --structured-commands   Alias for --output-format=json.',
+    '  -h, --help              Show this help message.',
+  ].join('\n');
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const options: ChatOptions = {};
+
+  for (const argument of argv) {
+    if (argument === '--') {
+      continue;
+    }
+
+    if (argument === '--help' || argument === '-h') {
+      return { options, shouldPrintHelp: true };
+    }
+
+    if (argument === '--debug-response') {
+      options.debugResponse = true;
+      continue;
+    }
+
+    if (argument === '--structured-commands') {
+      options.outputFormat = OUTPUT_FORMAT_PRESETS.json;
+      continue;
+    }
+
+    if (argument.startsWith('--output-format=')) {
+      options.outputFormat = parseOutputFormat(argument.slice('--output-format='.length));
+      continue;
+    }
+
+    if (argument.startsWith('--max-tokens=')) {
+      const value = Number(argument.slice('--max-tokens='.length));
+
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error('--max-tokens must be a positive integer.');
+      }
+
+      options.maxTokens = value;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  return { options, shouldPrintHelp: false };
+}

--- a/workspaces/ai-engineering/llm-chat/src/cli/readline.ts
+++ b/workspaces/ai-engineering/llm-chat/src/cli/readline.ts
@@ -1,0 +1,22 @@
+import { stdin, stdout } from 'node:process';
+import { createInterface } from 'node:readline';
+
+export interface InputAdapter {
+  ask(prompt: string): Promise<string>;
+  close(): void;
+}
+
+export function createReadlineInput(): InputAdapter {
+  const readline = createInterface({ input: stdin, output: stdout });
+
+  return {
+    ask(prompt) {
+      return new Promise<string>((resolve) => {
+        readline.question(prompt, resolve);
+      });
+    },
+    close() {
+      readline.close();
+    },
+  };
+}

--- a/workspaces/ai-engineering/llm-chat/src/cli/readline.ts
+++ b/workspaces/ai-engineering/llm-chat/src/cli/readline.ts
@@ -6,13 +6,37 @@ export interface InputAdapter {
   close(): void;
 }
 
-export function createReadlineInput(): InputAdapter {
-  const readline = createInterface({ input: stdin, output: stdout });
+export interface ReadlineInputOptions {
+  readonly input?: NodeJS.ReadableStream;
+  readonly output?: NodeJS.WritableStream;
+}
+
+export function createReadlineInput(options: ReadlineInputOptions = {}): InputAdapter {
+  const readline = createInterface({
+    input: options.input ?? stdin,
+    output: options.output ?? stdout,
+  });
+  let isClosed = false;
+  let pendingReject: ((error: Error) => void) | undefined;
+
+  readline.on('close', () => {
+    isClosed = true;
+    pendingReject?.(new Error('Readline input closed'));
+    pendingReject = undefined;
+  });
 
   return {
     ask(prompt) {
-      return new Promise<string>((resolve) => {
-        readline.question(prompt, resolve);
+      if (isClosed) {
+        return Promise.reject(new Error('Readline input closed'));
+      }
+
+      return new Promise<string>((resolve, reject) => {
+        pendingReject = reject;
+        readline.question(prompt, (answer) => {
+          pendingReject = undefined;
+          resolve(answer);
+        });
       });
     },
     close() {

--- a/workspaces/ai-engineering/llm-chat/src/cli/run-chatbot.ts
+++ b/workspaces/ai-engineering/llm-chat/src/cli/run-chatbot.ts
@@ -1,0 +1,66 @@
+import type { ChatOptions, Messages } from '../chat/types.js';
+
+export type InputFunction = (prompt: string) => Promise<string>;
+export type OutputFunction = (text: string) => void;
+export type OutputChunkFunction = (text: string) => void;
+export type TurnRunner = (
+  messages: Messages,
+  text: string,
+  options: ChatOptions,
+) => Promise<string>;
+
+export interface RunChatbotOptions {
+  readonly debugResponse?: boolean;
+  readonly input: InputFunction;
+  readonly maxTokens?: number;
+  readonly output?: OutputFunction;
+  readonly outputChunk?: OutputChunkFunction;
+  readonly outputFormat?: ChatOptions['outputFormat'];
+  readonly runTurn: TurnRunner;
+  readonly stream?: boolean;
+}
+
+export async function runChatbot(options: RunChatbotOptions): Promise<Messages> {
+  const messages: Messages = [];
+  const output = options.output ?? console.log;
+  const outputChunk = options.outputChunk ?? ((text) => process.stdout.write(text));
+
+  while (true) {
+    let userInput: string;
+
+    try {
+      userInput = await options.input('> ');
+    } catch {
+      output('');
+
+      return messages;
+    }
+
+    const chatOptions: ChatOptions = {};
+    let didStreamText = false;
+
+    if (options.maxTokens !== undefined) {
+      chatOptions.maxTokens = options.maxTokens;
+    }
+
+    if (options.debugResponse !== undefined) {
+      chatOptions.debugResponse = options.debugResponse;
+    }
+
+    chatOptions.stream = options.stream ?? true;
+
+    if (options.outputFormat) {
+      chatOptions.outputFormat = options.outputFormat;
+    }
+
+    chatOptions.onTextDelta = (text) => {
+      didStreamText = true;
+
+      outputChunk(text);
+    };
+
+    const answer = await options.runTurn(messages, userInput, chatOptions);
+
+    output(didStreamText ? '' : answer);
+  }
+}

--- a/workspaces/ai-engineering/llm-chat/src/config/env.ts
+++ b/workspaces/ai-engineering/llm-chat/src/config/env.ts
@@ -1,0 +1,28 @@
+import { config as loadDotenv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_MODEL = 'claude-sonnet-4-6';
+
+export interface AppConfig {
+  readonly anthropicApiKey: string;
+  readonly model: string;
+}
+
+export function loadEnvironment(envPath?: string): void {
+  loadDotenv({
+    path: envPath ?? fileURLToPath(new URL('../../.env', import.meta.url)),
+  });
+}
+
+export function loadConfig(): AppConfig {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY is not set. Add it to .env.');
+  }
+
+  return {
+    anthropicApiKey: apiKey,
+    model: process.env.ANTHROPIC_MODEL ?? DEFAULT_MODEL,
+  };
+}

--- a/workspaces/ai-engineering/llm-chat/src/llm/anthropic/client.ts
+++ b/workspaces/ai-engineering/llm-chat/src/llm/anthropic/client.ts
@@ -1,0 +1,5 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+export function createAnthropicClient(apiKey: string): Anthropic {
+  return new Anthropic({ apiKey });
+}

--- a/workspaces/ai-engineering/llm-chat/src/llm/anthropic/messages-api.ts
+++ b/workspaces/ai-engineering/llm-chat/src/llm/anthropic/messages-api.ts
@@ -1,0 +1,70 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages/messages';
+
+import type { LlmProvider, LlmRequest, LlmResponse } from '../types.js';
+import { textFromMessage } from './text.js';
+
+export function createAnthropicProvider(client: Anthropic): LlmProvider {
+  return {
+    async createMessage(request: LlmRequest): Promise<LlmResponse> {
+      const requestMessages: MessageParam[] = request.messages.map((message) => ({ ...message }));
+      const jsonSchema = request.outputFormat?.jsonSchema;
+      const assistantPrefill =
+        jsonSchema === undefined ? (request.outputFormat?.assistantPrefill ?? '') : '';
+      const responseSuffix =
+        jsonSchema === undefined ? (request.outputFormat?.responseSuffix ?? '') : '';
+      const system = [request.systemPrompt, request.outputFormat?.instructions]
+        .filter(Boolean)
+        .join('\n\n');
+
+      if (assistantPrefill) {
+        requestMessages.push({ content: assistantPrefill, role: 'assistant' });
+      }
+
+      const params = {
+        max_tokens: request.maxTokens,
+        messages: requestMessages,
+        model: request.model,
+        ...(request.outputFormat?.stopSequences?.length && jsonSchema === undefined
+          ? { stop_sequences: [...request.outputFormat.stopSequences] }
+          : {}),
+        ...(system ? { system } : {}),
+        ...(request.temperature === undefined ? {} : { temperature: request.temperature }),
+        ...(jsonSchema === undefined
+          ? {}
+          : { output_config: { format: { schema: jsonSchema, type: 'json_schema' as const } } }),
+      };
+
+      if (request.stream ?? true) {
+        const stream = client.messages.stream(params);
+
+        if (assistantPrefill && request.onTextDelta) {
+          request.onTextDelta(assistantPrefill);
+        }
+
+        if (request.onTextDelta) {
+          stream.on('text', request.onTextDelta);
+        }
+
+        const message = await stream.finalMessage();
+        const text = `${assistantPrefill}${textFromMessage(message)}${responseSuffix}`;
+
+        if (responseSuffix && request.onTextDelta) {
+          request.onTextDelta(responseSuffix);
+        }
+
+        return {
+          raw: message,
+          text,
+        };
+      }
+
+      const message = await client.messages.create(params);
+
+      return {
+        raw: message,
+        text: `${assistantPrefill}${textFromMessage(message)}${responseSuffix}`,
+      };
+    },
+  };
+}

--- a/workspaces/ai-engineering/llm-chat/src/llm/anthropic/text.ts
+++ b/workspaces/ai-engineering/llm-chat/src/llm/anthropic/text.ts
@@ -1,0 +1,8 @@
+import type { Message } from '@anthropic-ai/sdk/resources/messages/messages';
+
+export function textFromMessage(message: Message): string {
+  return message.content
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}

--- a/workspaces/ai-engineering/llm-chat/src/llm/provider-factory.ts
+++ b/workspaces/ai-engineering/llm-chat/src/llm/provider-factory.ts
@@ -1,0 +1,10 @@
+import type { AppConfig } from '../config/env.js';
+import { createAnthropicClient } from './anthropic/client.js';
+import { createAnthropicProvider } from './anthropic/messages-api.js';
+import type { LlmProvider } from './types.js';
+
+export function createProvider(config: AppConfig): LlmProvider {
+  const client = createAnthropicClient(config.anthropicApiKey);
+
+  return createAnthropicProvider(client);
+}

--- a/workspaces/ai-engineering/llm-chat/src/llm/types.ts
+++ b/workspaces/ai-engineering/llm-chat/src/llm/types.ts
@@ -1,0 +1,31 @@
+import type { Messages } from '../chat/types.js';
+
+export type TextDeltaHandler = (text: string) => void;
+
+export interface OutputFormatConfig {
+  readonly assistantPrefill?: string;
+  readonly instructions?: string;
+  readonly jsonSchema?: Record<string, unknown>;
+  readonly responseSuffix?: string;
+  readonly stopSequences?: readonly string[];
+}
+
+export interface LlmRequest {
+  readonly maxTokens: number;
+  readonly messages: Messages;
+  readonly model: string;
+  readonly onTextDelta?: TextDeltaHandler;
+  readonly outputFormat?: OutputFormatConfig;
+  readonly stream?: boolean;
+  readonly systemPrompt?: string;
+  readonly temperature?: number;
+}
+
+export interface LlmResponse {
+  readonly raw: unknown;
+  readonly text: string;
+}
+
+export interface LlmProvider {
+  createMessage(request: LlmRequest): Promise<LlmResponse>;
+}

--- a/workspaces/ai-engineering/llm-chat/src/main.ts
+++ b/workspaces/ai-engineering/llm-chat/src/main.ts
@@ -1,0 +1,47 @@
+import { createChatService } from './chat/service.js';
+import { helpText, parseArgs } from './cli/args.js';
+import { createReadlineInput } from './cli/readline.js';
+import { runChatbot } from './cli/run-chatbot.js';
+import { loadConfig, loadEnvironment } from './config/env.js';
+import { createProvider } from './llm/provider-factory.js';
+
+const SYSTEM_PROMPT = 'Answer as shortly as possible.';
+const TEMPERATURE = 0.2;
+const STREAM = true;
+
+async function main(): Promise<void> {
+  const parsedArgs = parseArgs(process.argv.slice(2));
+
+  if (parsedArgs.shouldPrintHelp) {
+    console.log(helpText());
+
+    return;
+  }
+
+  loadEnvironment();
+  const config = loadConfig();
+  const provider = createProvider(config);
+  const chatService = createChatService({
+    model: config.model,
+    provider,
+    systemPrompt: SYSTEM_PROMPT,
+    temperature: TEMPERATURE,
+  });
+
+  const input = createReadlineInput();
+
+  try {
+    await runChatbot({
+      ...parsedArgs.options,
+      input: (prompt) => input.ask(prompt),
+      runTurn: (messages, text, options) => chatService.sendUserTurn(messages, text, options),
+      stream: STREAM,
+    });
+  } finally {
+    input.close();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/workspaces/ai-engineering/llm-chat/src/main.ts
+++ b/workspaces/ai-engineering/llm-chat/src/main.ts
@@ -1,3 +1,6 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { createChatService } from './chat/service.js';
 import { helpText, parseArgs } from './cli/args.js';
 import { createReadlineInput } from './cli/readline.js';
@@ -42,6 +45,10 @@ async function main(): Promise<void> {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+export function isDirectExecution(moduleUrl: string, entrypointPath: string | undefined): boolean {
+  return entrypointPath !== undefined && fileURLToPath(moduleUrl) === path.resolve(entrypointPath);
+}
+
+if (isDirectExecution(import.meta.url, process.argv[1])) {
   await main();
 }

--- a/workspaces/ai-engineering/llm-chat/tests/chat/history.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/chat/history.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { addAssistantMessage, addUserMessage } from '../../src/chat/history.js';
+import type { Messages } from '../../src/chat/types.js';
+
+describe('chat history helpers', () => {
+  it('preserves conversation order', () => {
+    const messages: Messages = [];
+
+    addUserMessage(messages, 'Define quantum computing in one sentence');
+    addAssistantMessage(messages, 'Quantum computing uses quantum states.');
+    addUserMessage(messages, 'Write another sentence');
+
+    expect(messages).toEqual([
+      {
+        content: 'Define quantum computing in one sentence',
+        role: 'user',
+      },
+      {
+        content: 'Quantum computing uses quantum states.',
+        role: 'assistant',
+      },
+      {
+        content: 'Write another sentence',
+        role: 'user',
+      },
+    ]);
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/chat/service.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/chat/service.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createChatService } from '../../src/chat/service.js';
+import type { Messages } from '../../src/chat/types.js';
+import { DEFAULT_MODEL } from '../../src/config/env.js';
+import type { LlmProvider, LlmRequest, LlmResponse } from '../../src/llm/types.js';
+
+const noop = (): null => null;
+
+function createFakeProvider(text: string): {
+  calls: LlmRequest[];
+  provider: LlmProvider;
+} {
+  const calls: LlmRequest[] = [];
+  const provider: LlmProvider = {
+    createMessage(request) {
+      calls.push({ ...request, messages: request.messages.map((m) => ({ ...m })) });
+
+      const response: LlmResponse = { raw: { text }, text };
+
+      return Promise.resolve(response);
+    },
+  };
+
+  return { calls, provider };
+}
+
+describe('chat service', () => {
+  it('appends user and assistant turns and forwards model and tokens', async () => {
+    const messages: Messages = [];
+    const { calls, provider } = createFakeProvider('Hi');
+
+    const service = createChatService({ model: DEFAULT_MODEL, provider });
+    const answer = await service.sendUserTurn(messages, 'Hello', { maxTokens: 100 });
+
+    expect(answer).toBe('Hi');
+    expect(messages).toEqual([
+      { content: 'Hello', role: 'user' },
+      { content: 'Hi', role: 'assistant' },
+    ]);
+    expect(calls).toEqual([
+      {
+        maxTokens: 100,
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: DEFAULT_MODEL,
+        stream: true,
+      },
+    ]);
+  });
+
+  it('forwards a configured system prompt to the provider', async () => {
+    const messages: Messages = [];
+    const { calls, provider } = createFakeProvider('Hi');
+
+    const service = createChatService({
+      model: DEFAULT_MODEL,
+      provider,
+      systemPrompt: 'Answer like a senior backend mentor.',
+    });
+
+    await service.sendUserTurn(messages, 'Hello');
+
+    expect(calls[0]).toMatchObject({
+      systemPrompt: 'Answer like a senior backend mentor.',
+    });
+  });
+
+  it('forwards a configured temperature to the provider', async () => {
+    const messages: Messages = [];
+    const { calls, provider } = createFakeProvider('Hi');
+
+    const service = createChatService({
+      model: DEFAULT_MODEL,
+      provider,
+      temperature: 0.2,
+    });
+
+    await service.sendUserTurn(messages, 'Hello');
+
+    expect(calls[0]).toMatchObject({
+      temperature: 0.2,
+    });
+  });
+
+  it('forwards streaming options to the provider', async () => {
+    const messages: Messages = [];
+    const { calls, provider } = createFakeProvider('Hi');
+    const onTextDelta = vi.fn();
+
+    const service = createChatService({ model: DEFAULT_MODEL, provider });
+    await service.sendUserTurn(messages, 'Hello', { onTextDelta, stream: false });
+
+    expect(calls[0]).toMatchObject({
+      onTextDelta,
+      stream: false,
+    });
+  });
+
+  it('forwards output format options to the provider', async () => {
+    const messages: Messages = [];
+    const { calls, provider } = createFakeProvider('{"commands":[]}');
+
+    const service = createChatService({ model: DEFAULT_MODEL, provider });
+    await service.sendUserTurn(messages, 'Give me three git commands', {
+      outputFormat: {
+        instructions:
+          'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+      },
+    });
+
+    expect(calls[0]).toMatchObject({
+      outputFormat: {
+        instructions:
+          'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+      },
+    });
+  });
+
+  it('uses the default max tokens when no per-turn value is given', async () => {
+    const messages: Messages = [];
+    const { calls, provider } = createFakeProvider('ok');
+
+    const service = createChatService({ model: 'm', provider });
+    await service.sendUserTurn(messages, 'hi');
+
+    expect(calls[0]?.maxTokens).toBe(1000);
+  });
+
+  it('logs the raw response when debugResponse is set', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(noop);
+    const messages: Messages = [];
+    const { provider } = createFakeProvider('ok');
+
+    const service = createChatService({ model: 'm', provider });
+    await service.sendUserTurn(messages, 'hi', { debugResponse: true });
+
+    expect(logSpy).toHaveBeenCalledWith('Full response:', { text: 'ok' });
+    logSpy.mockRestore();
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/cli/args.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/cli/args.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { helpText, parseArgs } from '../../src/cli/args.js';
+
+const JSON_PRESET_SCHEMA = {
+  additionalProperties: false,
+  properties: {
+    commands: {
+      items: { type: 'string' },
+      type: 'array',
+    },
+  },
+  required: ['commands'],
+  type: 'object',
+};
+
+describe('parseArgs', () => {
+  it('returns empty options when no args are given', () => {
+    expect(parseArgs([])).toEqual({ options: {}, shouldPrintHelp: false });
+  });
+
+  it('flags help for --help and -h', () => {
+    expect(parseArgs(['--help']).shouldPrintHelp).toBe(true);
+    expect(parseArgs(['-h']).shouldPrintHelp).toBe(true);
+  });
+
+  it('parses --debug-response, --max-tokens, and --structured-commands', () => {
+    expect(parseArgs(['--debug-response', '--max-tokens=512', '--structured-commands'])).toEqual({
+      options: {
+        debugResponse: true,
+        maxTokens: 512,
+        outputFormat: {
+          instructions:
+            'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+          jsonSchema: JSON_PRESET_SCHEMA,
+        },
+      },
+      shouldPrintHelp: false,
+    });
+  });
+
+  it('parses output format presets', () => {
+    expect(parseArgs(['--output-format=json']).options.outputFormat).toEqual({
+      instructions:
+        'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+      jsonSchema: JSON_PRESET_SCHEMA,
+    });
+    expect(parseArgs(['--output-format=csv']).options.outputFormat).toEqual({
+      instructions:
+        'Return the response as CSV only. Include a header row. Do not include comments, markdown fences, or explanation.',
+    });
+    expect(parseArgs(['--output-format=html']).options.outputFormat).toEqual({
+      instructions:
+        'Return the response as HTML only. Use an unordered list when listing items. Do not include comments, markdown fences, or explanation.',
+    });
+  });
+
+  it('ignores the forwarded pnpm delimiter', () => {
+    expect(parseArgs(['--', '--output-format=json']).options.outputFormat).toEqual({
+      instructions:
+        'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+      jsonSchema: JSON_PRESET_SCHEMA,
+    });
+  });
+
+  it('rejects unsupported output formats', () => {
+    expect(() => parseArgs(['--output-format=xml'])).toThrow(/json, csv, html/);
+  });
+
+  it('rejects non-positive or non-integer max tokens', () => {
+    expect(() => parseArgs(['--max-tokens=0'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--max-tokens=abc'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--max-tokens=-5'])).toThrow(/positive integer/);
+  });
+
+  it('rejects unknown arguments', () => {
+    expect(() => parseArgs(['--nope'])).toThrow(/Unknown argument/);
+  });
+});
+
+describe('helpText', () => {
+  it('mentions both flags', () => {
+    const text = helpText();
+
+    expect(text).toContain('--max-tokens');
+    expect(text).toContain('--debug-response');
+    expect(text).toContain('--output-format');
+    expect(text).toContain('--structured-commands');
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/cli/readline.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/cli/readline.test.ts
@@ -1,0 +1,42 @@
+import { PassThrough, Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+
+import { createReadlineInput } from '../../src/cli/readline.js';
+
+function createDiscardOutput(): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}
+
+describe('createReadlineInput', () => {
+  it('reads a line from the configured input stream', async () => {
+    const input = new PassThrough();
+    const readlineInput = createReadlineInput({
+      input,
+      output: createDiscardOutput(),
+    });
+
+    const answer = readlineInput.ask('> ');
+    input.write('Hello\n');
+
+    await expect(answer).resolves.toBe('Hello');
+
+    readlineInput.close();
+  });
+
+  it('rejects a pending question when stdin reaches EOF', async () => {
+    const input = new PassThrough();
+    const readlineInput = createReadlineInput({
+      input,
+      output: createDiscardOutput(),
+    });
+
+    const answer = readlineInput.ask('> ');
+    input.push(null);
+
+    await expect(answer).rejects.toThrow('Readline input closed');
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/cli/run-chatbot.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/cli/run-chatbot.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { addAssistantMessage, addUserMessage } from '../../src/chat/history.js';
+import type { Messages } from '../../src/chat/types.js';
+import { runChatbot } from '../../src/cli/run-chatbot.js';
+
+describe('runChatbot', () => {
+  it('repeats until input stops', async () => {
+    const prompts: string[] = [];
+    const outputs: string[] = [];
+    const userInputs = ['Hello', 'Write another sentence'];
+    const requests: Messages[] = [];
+
+    const messages = await runChatbot({
+      debugResponse: true,
+      input: (prompt) => {
+        prompts.push(prompt);
+        const nextInput = userInputs.shift();
+
+        if (nextInput === undefined) {
+          throw new Error('No more input');
+        }
+
+        return Promise.resolve(nextInput);
+      },
+      maxTokens: 50,
+      output: (text) => {
+        outputs.push(text);
+      },
+      outputFormat: {
+        assistantPrefill: '{',
+        responseSuffix: '}',
+        stopSequences: ['}'],
+      },
+      runTurn: (messages, text, options) => {
+        expect(options.maxTokens).toBe(50);
+        expect(options.debugResponse).toBe(true);
+        expect(options.stream).toBe(true);
+        expect(options.onTextDelta).toEqual(expect.any(Function));
+        expect(options.outputFormat).toEqual({
+          assistantPrefill: '{',
+          responseSuffix: '}',
+          stopSequences: ['}'],
+        });
+
+        const answer = `Answer to: ${text}`;
+        addUserMessage(messages, text);
+        requests.push(messages.map((message) => ({ ...message })));
+        addAssistantMessage(messages, answer);
+
+        return Promise.resolve(answer);
+      },
+    });
+
+    expect(prompts).toEqual(['> ', '> ', '> ']);
+    expect(requests).toEqual([
+      [{ content: 'Hello', role: 'user' }],
+      [
+        { content: 'Hello', role: 'user' },
+        { content: 'Answer to: Hello', role: 'assistant' },
+        { content: 'Write another sentence', role: 'user' },
+      ],
+    ]);
+
+    expect(outputs).toEqual(['Answer to: Hello', 'Answer to: Write another sentence', '']);
+    expect(messages).toEqual([
+      { content: 'Hello', role: 'user' },
+      { content: 'Answer to: Hello', role: 'assistant' },
+      { content: 'Write another sentence', role: 'user' },
+      {
+        content: 'Answer to: Write another sentence',
+        role: 'assistant',
+      },
+    ]);
+  });
+
+  it('outputs streamed chunks and does not duplicate the final answer', async () => {
+    const outputs: string[] = [];
+    const chunks: string[] = [];
+    const userInputs = ['Hello'];
+
+    await runChatbot({
+      input: () => {
+        const nextInput = userInputs.shift();
+
+        if (nextInput === undefined) {
+          throw new Error('No more input');
+        }
+
+        return Promise.resolve(nextInput);
+      },
+      output: (text) => {
+        outputs.push(text);
+      },
+      outputChunk: (text) => {
+        chunks.push(text);
+      },
+      runTurn: (messages, text, options) => {
+        addUserMessage(messages, text);
+        options.onTextDelta?.('Hel');
+        options.onTextDelta?.('lo');
+        addAssistantMessage(messages, 'Hello');
+
+        return Promise.resolve('Hello');
+      },
+    });
+
+    expect(chunks).toEqual(['Hel', 'lo']);
+    expect(outputs).toEqual(['', '']);
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/llm/anthropic/messages-api.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/llm/anthropic/messages-api.test.ts
@@ -1,0 +1,189 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_MODEL } from '../../../src/config/env.js';
+import { createAnthropicProvider } from '../../../src/llm/anthropic/messages-api.js';
+
+describe('createAnthropicProvider', () => {
+  it('streams messages by default and extracts final text', async () => {
+    const on = vi.fn().mockReturnThis();
+    const finalMessage = vi.fn().mockResolvedValue({
+      content: [{ text: 'Hi', type: 'text' }],
+    });
+    const stream = vi.fn().mockReturnValue({ finalMessage, on });
+    const client = { messages: { stream } } as unknown as Anthropic;
+    const onTextDelta = vi.fn();
+
+    const provider = createAnthropicProvider(client);
+    const response = await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: DEFAULT_MODEL,
+      onTextDelta,
+      systemPrompt: 'Answer with short examples.',
+      temperature: 0.2,
+    });
+
+    expect(response.text).toBe('Hi');
+    expect(response.raw).toEqual({ content: [{ text: 'Hi', type: 'text' }] });
+    expect(on).toHaveBeenCalledWith('text', onTextDelta);
+    expect(stream).toHaveBeenCalledWith({
+      max_tokens: 100,
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: DEFAULT_MODEL,
+      system: 'Answer with short examples.',
+      temperature: 0.2,
+    });
+  });
+
+  it('uses assistant prefill and stop sequences for an output format', async () => {
+    const on = vi.fn().mockReturnThis();
+    const finalMessage = vi.fn().mockResolvedValue({
+      content: [{ text: 'pnpm install",\n    "pnpm test",\n    "pnpm build"', type: 'text' }],
+    });
+    const stream = vi.fn().mockReturnValue({ finalMessage, on });
+    const client = { messages: { stream } } as unknown as Anthropic;
+    const onTextDelta = vi.fn();
+
+    const provider = createAnthropicProvider(client);
+    const response = await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'Give me three pnpm commands', role: 'user' }],
+      model: DEFAULT_MODEL,
+      onTextDelta,
+      outputFormat: {
+        assistantPrefill: '{\n  "commands": [\n    "',
+        instructions:
+          'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+        responseSuffix: '\n  ]\n}',
+        stopSequences: ['\n  ]\n}'],
+      },
+    });
+
+    expect(response.text).toBe(
+      '{\n  "commands": [\n    "pnpm install",\n    "pnpm test",\n    "pnpm build"\n  ]\n}',
+    );
+    expect(onTextDelta).toHaveBeenNthCalledWith(1, '{\n  "commands": [\n    "');
+    expect(onTextDelta).toHaveBeenLastCalledWith('\n  ]\n}');
+    expect(stream).toHaveBeenCalledWith({
+      max_tokens: 100,
+      messages: [
+        { content: 'Give me three pnpm commands', role: 'user' },
+        { content: '{\n  "commands": [\n    "', role: 'assistant' },
+      ],
+      model: DEFAULT_MODEL,
+      stop_sequences: ['\n  ]\n}'],
+      system:
+        'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+    });
+  });
+
+  it('uses output format instructions without assistant prefill', async () => {
+    const on = vi.fn().mockReturnThis();
+    const finalMessage = vi.fn().mockResolvedValue({
+      content: [{ text: '{"commands":["aws s3 ls"]}', type: 'text' }],
+    });
+    const stream = vi.fn().mockReturnValue({ finalMessage, on });
+    const client = { messages: { stream } } as unknown as Anthropic;
+
+    const provider = createAnthropicProvider(client);
+    const response = await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'Give me one AWS CLI command', role: 'user' }],
+      model: DEFAULT_MODEL,
+      outputFormat: {
+        instructions:
+          'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+      },
+    });
+
+    expect(response.text).toBe('{"commands":["aws s3 ls"]}');
+    expect(stream).toHaveBeenCalledWith({
+      max_tokens: 100,
+      messages: [{ content: 'Give me one AWS CLI command', role: 'user' }],
+      model: DEFAULT_MODEL,
+      system:
+        'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+    });
+  });
+
+  it('uses output_config.format when jsonSchema is set and does not append assistant prefill', async () => {
+    const on = vi.fn().mockReturnThis();
+    const finalMessage = vi.fn().mockResolvedValue({
+      content: [{ text: '{"commands":["git status"]}', type: 'text' }],
+    });
+    const stream = vi.fn().mockReturnValue({ finalMessage, on });
+    const client = { messages: { stream } } as unknown as Anthropic;
+    const onTextDelta = vi.fn();
+
+    const provider = createAnthropicProvider(client);
+    const response = await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'Give me one git command', role: 'user' }],
+      model: DEFAULT_MODEL,
+      onTextDelta,
+      outputFormat: {
+        instructions:
+          'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+        jsonSchema: {
+          additionalProperties: false,
+          properties: {
+            commands: {
+              items: { type: 'string' },
+              type: 'array',
+            },
+          },
+          required: ['commands'],
+          type: 'object',
+        },
+      },
+    });
+
+    expect(response.text).toBe('{"commands":["git status"]}');
+    expect(stream).toHaveBeenCalledWith({
+      max_tokens: 100,
+      messages: [{ content: 'Give me one git command', role: 'user' }],
+      model: DEFAULT_MODEL,
+      output_config: {
+        format: {
+          schema: {
+            additionalProperties: false,
+            properties: {
+              commands: {
+                items: { type: 'string' },
+                type: 'array',
+              },
+            },
+            required: ['commands'],
+            type: 'object',
+          },
+          type: 'json_schema',
+        },
+      },
+      system:
+        'Return the response as JSON only. Use this shape when returning commands: {"commands":["..."]}. Do not include comments, markdown fences, or explanation.',
+    });
+  });
+
+  it('can create non-streaming messages', async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ text: 'Hi', type: 'text' }],
+    });
+    const client = { messages: { create } } as unknown as Anthropic;
+
+    const provider = createAnthropicProvider(client);
+    const response = await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: DEFAULT_MODEL,
+      stream: false,
+    });
+
+    expect(response.text).toBe('Hi');
+    expect(create).toHaveBeenCalledWith({
+      max_tokens: 100,
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: DEFAULT_MODEL,
+    });
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/llm/anthropic/text.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/llm/anthropic/text.test.ts
@@ -1,0 +1,24 @@
+import type { Message } from '@anthropic-ai/sdk/resources/messages/messages';
+import { describe, expect, it } from 'vitest';
+
+import { textFromMessage } from '../../../src/llm/anthropic/text.js';
+
+describe('textFromMessage', () => {
+  it('joins text blocks and ignores non-text blocks', () => {
+    const message = {
+      content: [
+        { text: 'Hello', type: 'text' },
+        { name: 'tool', type: 'tool_use' },
+        { text: 'world', type: 'text' },
+      ],
+    } as unknown as Message;
+
+    expect(textFromMessage(message)).toBe('Hello\nworld');
+  });
+
+  it('returns an empty string when there are no text blocks', () => {
+    const message = { content: [] } as unknown as Message;
+
+    expect(textFromMessage(message)).toBe('');
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/llm/provider-factory.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/llm/provider-factory.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_MODEL } from '../../src/config/env.js';
+import { createProvider } from '../../src/llm/provider-factory.js';
+
+describe('createProvider', () => {
+  it('returns an LlmProvider with createMessage', () => {
+    const provider = createProvider({
+      anthropicApiKey: 'test-key',
+      model: DEFAULT_MODEL,
+    });
+
+    expect(typeof provider.createMessage).toBe('function');
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tests/main.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/main.test.ts
@@ -1,0 +1,20 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { isDirectExecution } from '../src/main.js';
+
+describe('isDirectExecution', () => {
+  it('matches paths whose file URLs require encoding', () => {
+    const entrypointPath = path.resolve('workspaces/ai-engineering/llm-chat/tmp path/main.ts');
+
+    expect(isDirectExecution(pathToFileURL(entrypointPath).href, entrypointPath)).toBe(true);
+  });
+
+  it('does not match a different entrypoint path', () => {
+    const modulePath = path.resolve('workspaces/ai-engineering/llm-chat/src/main.ts');
+    const entrypointPath = path.resolve('workspaces/ai-engineering/llm-chat/src/other.ts');
+
+    expect(isDirectExecution(pathToFileURL(modulePath).href, entrypointPath)).toBe(false);
+  });
+});

--- a/workspaces/ai-engineering/llm-chat/tsconfig.json
+++ b/workspaces/ai-engineering/llm-chat/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
+}

--- a/workspaces/ai-engineering/llm-chat/vitest.config.ts
+++ b/workspaces/ai-engineering/llm-chat/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
- add provider-neutral chat service, CLI args, readline loop, and Anthropic adapter
- support streaming responses and optional json/csv/html output formatting
- register the ai-engineering workspace and document the new llm-chat example
- add Vitest coverage for chat, CLI parsing, provider formatting, and Anthropic response handling