### PR TITLE
feat(prompt-eval-lab): add HTML report output and harden report pipeline

### DIFF
--- a/workspaces/ai-engineering/prompt-eval-lab/.gitignore
+++ b/workspaces/ai-engineering/prompt-eval-lab/.gitignore
@@ -5,4 +5,5 @@ coverage/
 .env
 .env.*
 !.env.example
+reports/*.html
 reports/*.json

--- a/workspaces/ai-engineering/prompt-eval-lab/README.md
+++ b/workspaces/ai-engineering/prompt-eval-lab/README.md
@@ -31,10 +31,18 @@ Run the eval against the bundled example dataset:
 pnpm dev -- --dataset=datasets/basic-code-assistant.dataset.json
 ```
 
-Write a JSON report alongside the console output:
+The default run writes a timestamped HTML report under `reports/` alongside the console output.
+
+Write a JSON report instead:
 
 ```bash
 pnpm dev -- --dataset=datasets/basic-code-assistant.dataset.json --out=reports/run.json
+```
+
+Choose a custom HTML report path:
+
+```bash
+pnpm dev -- --dataset=datasets/basic-code-assistant.dataset.json --out=reports/run.html
 ```
 
 From the repository root:
@@ -45,23 +53,27 @@ pnpm --filter prompt-eval-lab dev -- --dataset=datasets/basic-code-assistant.dat
 
 ## CLI Options
 
-| Flag                | Required | Default             | Notes                               |
-| ------------------- | -------- | ------------------- | ----------------------------------- |
-| `--dataset=<path>`  | yes      | —                   | JSON dataset file.                  |
-| `--prompt=<name>`   | no       | `code-assistant.v1` | Registered prompt template.         |
-| `--out=<path>`      | no       | (no file written)   | Write a JSON report to this path.   |
-| `--model=<id>`      | no       | `ANTHROPIC_MODEL`   | Override env-configured model.      |
-| `--max-tokens=<n>`  | no       | `1024`              | Max tokens per LLM call.            |
-| `--concurrency=<n>` | no       | `3`                 | Parallel test cases. Range `1..10`. |
-| `-h`, `--help`      | no       | —                   | Show help.                          |
+| Flag                | Required | Default             | Notes                                          |
+| ------------------- | -------- | ------------------- | ---------------------------------------------- |
+| `--dataset=<path>`  | yes      | —                   | JSON dataset file.                             |
+| `--prompt=<name>`   | no       | `code-assistant.v1` | Registered prompt template.                    |
+| `--out=<path>`      | no       | `reports/*.html`    | Override report path; `.json` writes raw JSON. |
+| `--model=<id>`      | no       | `ANTHROPIC_MODEL`   | Override env-configured model.                 |
+| `--max-tokens=<n>`  | no       | `1024`              | Max tokens per LLM call.                       |
+| `--concurrency=<n>` | no       | `3`                 | Parallel test cases. Range `1..10`.            |
+| `-h`, `--help`      | no       | —                   | Show help.                                     |
 
 ## Dataset Format
 
-Each test case has a `task`, a `format` (`json` | `typescript` | `regex`), and `solution_criteria`:
+Each test case has a `task`, a `format` (`json` | `typescript` | `regex`), and `solution_criteria`. Optional `scenario` and `prompt_inputs` fields make HTML reports easier to scan:
 
 ```json
 [
   {
+    "scenario": "TypeScript utility function",
+    "prompt_inputs": {
+      "content": "A description or source text to include in the report"
+    },
     "task": "Write a TypeScript function that does X.",
     "format": "typescript",
     "solution_criteria": "Function takes a string and returns a string."
@@ -85,11 +97,21 @@ The summary prints the overall average plus a per-format breakdown.
 Structured outputs reduce JSON parsing failures for the grader, but the CLI
 still treats the parsed grader response as untrusted and validates it locally.
 
+## Reports
+
+By default, each run writes a timestamped browser-friendly HTML report to `reports/`. Use `--out=reports/run.html` to choose the HTML path. Use `--out=reports/run.json` for the raw JSON payload used by automation.
+
+The HTML report includes:
+
+- summary cards for total test cases, average score, and pass rate using score `>=9`;
+- a table with scenario, prompt inputs, solution criteria, output, score, and reasoning;
+- HTML escaping for model output and dataset text.
+
 ## Source Map
 
 - `src/main.ts` — thin CLI bootstrap.
 - `src/cli/args.ts` — flag parser.
-- `src/cli/run-eval.ts` — orchestrates env load, dataset load, runner, summary, optional report file.
+- `src/cli/run-eval.ts` — orchestrates env load, dataset load, runner, summary, and report file output.
 - `src/config/env.ts` — `.env` loading wrapper that supplies the local `.env` path to `@workspaces/packages/llm-client`.
 - `src/datasets/types.ts`, `load-dataset.ts` — Zod-validated dataset model.
 - `src/prompts/templates.ts`, `render-prompt.ts` — named-template registry and `{{var}}` interpolator.
@@ -98,6 +120,8 @@ still treats the parsed grader response as untrusted and validates it locally.
 - `src/eval/summary.ts` — pure summary + console formatter.
 - `src/graders/code-validators.ts` — JSON / regex / TypeScript syntax validators.
 - `src/graders/model-grader.ts` — model-based grader using structured outputs.
+- `src/reports/write-report.ts` — report format dispatcher and default path helper.
+- `src/reports/write-html-report.ts` — HTML report writer.
 - `src/reports/write-json-report.ts` — JSON report writer.
 
 ## Testing

--- a/workspaces/ai-engineering/prompt-eval-lab/src/cli/args.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/cli/args.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { DEFAULT_CONCURRENCY, MAX_CONCURRENCY, MIN_CONCURRENCY } from '../eval/runner.js';
 import { DEFAULT_TEMPLATE_NAME, isTemplateName, type TemplateName } from '../prompts/templates.js';
 
@@ -26,7 +28,7 @@ export function helpText(): string {
     '',
     'Options:',
     `  --prompt=<name>           Prompt template name (default: ${DEFAULT_TEMPLATE_NAME}).`,
-    '  --out=<path>              Write a JSON report to this path.',
+    '  --out=<path>              Report path (default: timestamped .html in reports/; use .json for raw JSON).',
     '  --model=<id>              Override the ANTHROPIC_MODEL env value.',
     '  --max-tokens=<n>          Max tokens per LLM call (positive integer).',
     `  --concurrency=<n>         Parallel test cases (default: ${DEFAULT_CONCURRENCY}, range ${MIN_CONCURRENCY}..${MAX_CONCURRENCY}).`,
@@ -68,7 +70,14 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
     }
 
     if (argument.startsWith('--out=')) {
-      outPath = argument.slice('--out='.length);
+      const value = argument.slice('--out='.length);
+      const ext = path.extname(value).toLowerCase();
+
+      if (ext !== '.html' && ext !== '.json') {
+        throw new Error('--out must have a .html or .json extension.');
+      }
+
+      outPath = value;
       continue;
     }
 

--- a/workspaces/ai-engineering/prompt-eval-lab/src/cli/run-eval.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/cli/run-eval.ts
@@ -7,9 +7,10 @@ import { formatSummaryLines, summarize } from '../eval/summary.js';
 import { loadTemplate } from '../prompts/templates.js';
 import {
   defaultReportPath,
+  PASS_SCORE,
   type ReportPayload,
-  writeJsonReport,
-} from '../reports/write-json-report.js';
+  writeReport,
+} from '../reports/write-report.js';
 import type { CliOptions } from './args.js';
 
 export interface RunEvalIo {
@@ -46,22 +47,21 @@ export async function runEvalCli(options: CliOptions, io: RunEvalIo = {}): Promi
     log(line);
   }
 
-  if (options.outPath) {
-    const payload: ReportPayload = {
-      metadata: {
-        concurrency: options.concurrency,
-        datasetPath: options.datasetPath,
-        finishedAt: finishedAt.toISOString(),
-        model,
-        startedAt: startedAt.toISOString(),
-        templateName: options.templateName,
-      },
-      results,
-      summary,
-    };
+  const payload: ReportPayload = {
+    metadata: {
+      concurrency: options.concurrency,
+      datasetPath: options.datasetPath,
+      finishedAt: finishedAt.toISOString(),
+      model,
+      startedAt: startedAt.toISOString(),
+      templateName: options.templateName,
+    },
+    passScore: PASS_SCORE,
+    results,
+    summary,
+  };
 
-    const filePath = options.outPath || defaultReportPath('reports', finishedAt);
-    await writeJsonReport(filePath, payload);
-    log(`Wrote report to ${filePath}`);
-  }
+  const filePath = options.outPath ?? defaultReportPath('reports', finishedAt);
+  const format = await writeReport(filePath, payload);
+  log(`Wrote ${format.toUpperCase()} report to ${filePath}`);
 }

--- a/workspaces/ai-engineering/prompt-eval-lab/src/datasets/types.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/datasets/types.ts
@@ -6,6 +6,8 @@ export type TestCaseFormat = z.infer<typeof testCaseFormatSchema>;
 
 export const testCaseSchema = z.object({
   format: testCaseFormatSchema,
+  prompt_inputs: z.record(z.string(), z.string()).optional(),
+  scenario: z.string().min(1).optional(),
   solution_criteria: z.string().min(1),
   task: z.string().min(1),
 });

--- a/workspaces/ai-engineering/prompt-eval-lab/src/graders/model-grader.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/graders/model-grader.ts
@@ -24,7 +24,7 @@ export const GRADER_JSON_SCHEMA: Record<string, unknown> = {
   additionalProperties: false,
   properties: {
     reasoning: { type: 'string' },
-    score: { maximum: 10, minimum: 1, type: 'number' },
+    score: { type: 'number' },
     strengths: { items: { type: 'string' }, type: 'array' },
     weaknesses: { items: { type: 'string' }, type: 'array' },
   },

--- a/workspaces/ai-engineering/prompt-eval-lab/src/reports/types.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/reports/types.ts
@@ -1,0 +1,19 @@
+import type { EvalResult, EvalSummary } from '../eval/types.js';
+
+export interface RunMetadata {
+  readonly concurrency: number;
+  readonly datasetPath: string;
+  readonly finishedAt: string;
+  readonly model: string;
+  readonly startedAt: string;
+  readonly templateName: string;
+}
+
+export interface ReportPayload {
+  readonly metadata: RunMetadata;
+  readonly passScore: number;
+  readonly results: readonly EvalResult[];
+  readonly summary: EvalSummary;
+}
+
+export type ReportFormat = 'html' | 'json';

--- a/workspaces/ai-engineering/prompt-eval-lab/src/reports/write-html-report.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/reports/write-html-report.ts
@@ -1,0 +1,338 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { EvalResult } from '../eval/types.js';
+import type { ReportPayload } from './types.js';
+
+export const PASS_SCORE = 9;
+const SCORE_MID_THRESHOLD = 4;
+
+export async function writeHtmlReport(filePath: string, payload: ReportPayload): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, renderHtmlReport(payload), 'utf8');
+}
+
+export function renderHtmlReport(payload: ReportPayload): string {
+  const { passScore } = payload;
+  const rows = payload.results.map((result) => renderResultRow(result, passScore)).join('\n');
+  const passRate = percentage(passCount(payload.results, passScore), payload.summary.total);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Prompt Evaluation Report</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f2f3f5;
+      --panel: #ffffff;
+      --border: #d8dbe0;
+      --header: #3a3a3a;
+      --muted: #5e6570;
+      --text: #1f2933;
+      --score-good-bg: #dcfce7;
+      --score-good-text: #166534;
+      --score-mid-bg: #fef3c7;
+      --score-mid-text: #92400e;
+      --score-low-bg: #ffe4e6;
+      --score-low-text: #be123c;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    main {
+      padding: 24px;
+    }
+
+    h1 {
+      margin: 0 0 24px;
+      font-size: 30px;
+      line-height: 1.15;
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(180px, 1fr));
+      gap: 24px;
+      margin-bottom: 24px;
+      padding: 16px;
+      background: #eceeef;
+      border-radius: 2px;
+    }
+
+    .card {
+      min-height: 96px;
+      padding: 18px;
+      background: var(--panel);
+      border: 1px solid #e6e8eb;
+      border-radius: 4px;
+      box-shadow: 0 2px 7px rgb(15 23 42 / 0.12);
+    }
+
+    .card-label {
+      margin-bottom: 12px;
+      color: #3f4650;
+      font-weight: 650;
+    }
+
+    .card-value {
+      font-size: 24px;
+      font-weight: 750;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+    }
+
+    th {
+      padding: 14px 12px;
+      background: var(--header);
+      color: #fff;
+      text-align: left;
+      font-weight: 700;
+      vertical-align: top;
+    }
+
+    td {
+      padding: 14px 12px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+
+    .scenario {
+      width: 20%;
+      min-width: 220px;
+    }
+
+    .inputs,
+    .criteria,
+    .output,
+    .reasoning {
+      width: 20%;
+      min-width: 240px;
+    }
+
+    .score {
+      width: 72px;
+      min-width: 72px;
+      text-align: center;
+    }
+
+    .prompt-input,
+    .criteria-line {
+      margin: 0 0 6px;
+    }
+
+    .prompt-input strong {
+      font-weight: 750;
+    }
+
+    pre {
+      max-width: 420px;
+      margin: 0;
+      padding: 12px;
+      overflow: auto;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      background: #f5f6f8;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      font: 13px/1.45 "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    }
+
+    .badge {
+      display: inline-flex;
+      min-width: 32px;
+      min-height: 32px;
+      align-items: center;
+      justify-content: center;
+      border-radius: 3px;
+      font-weight: 800;
+    }
+
+    .score-good {
+      background: var(--score-good-bg);
+      color: var(--score-good-text);
+    }
+
+    .score-mid {
+      background: var(--score-mid-bg);
+      color: var(--score-mid-text);
+    }
+
+    .score-low {
+      background: var(--score-low-bg);
+      color: var(--score-low-text);
+    }
+
+    .meta {
+      margin: -14px 0 20px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 900px) {
+      main {
+        padding: 16px;
+      }
+
+      .summary {
+        grid-template-columns: 1fr;
+      }
+
+      table {
+        display: block;
+        overflow-x: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Prompt Evaluation Report</h1>
+    <p class="meta">Model: ${escapeHtml(payload.metadata.model)} | Dataset: ${escapeHtml(payload.metadata.datasetPath)} | Finished: ${escapeHtml(payload.metadata.finishedAt)}</p>
+    <section class="summary" aria-label="Run summary">
+      <article class="card">
+        <div class="card-label">Total Test Cases</div>
+        <div class="card-value">${payload.summary.total}</div>
+      </article>
+      <article class="card">
+        <div class="card-label">Average Score</div>
+        <div class="card-value">${formatScore(payload.summary.averageScore)} / 10</div>
+      </article>
+      <article class="card">
+        <div class="card-label">Pass Rate (&ge;${passScore})</div>
+        <div class="card-value">${passRate.toFixed(1)}%</div>
+      </article>
+    </section>
+    <table>
+      <thead>
+        <tr>
+          <th class="scenario">Scenario</th>
+          <th class="inputs">Prompt Inputs</th>
+          <th class="criteria">Solution Criteria</th>
+          <th class="output">Output</th>
+          <th class="score">Score</th>
+          <th class="reasoning">Reasoning</th>
+        </tr>
+      </thead>
+      <tbody>
+${rows}
+      </tbody>
+    </table>
+  </main>
+</body>
+</html>
+`;
+}
+
+function renderResultRow(result: EvalResult, passScore: number): string {
+  return `        <tr>
+          <td>${escapeMultiline(result.testCase.scenario ?? result.testCase.task)}</td>
+          <td>${renderPromptInputs(result)}</td>
+          <td>${renderCriteria(result.testCase.solution_criteria)}</td>
+          <td><pre>${escapeHtml(result.output)}</pre></td>
+          <td class="score"><span class="badge ${scoreClass(result.score, passScore)}">${formatScore(result.score)}</span></td>
+          <td>${escapeMultiline(result.modelGrade.reasoning)}</td>
+        </tr>`;
+}
+
+function renderPromptInputs(result: EvalResult): string {
+  const entries = Object.entries(result.testCase.prompt_inputs ?? {});
+
+  if (entries.length === 0) {
+    return `<p class="prompt-input">${escapeMultiline(result.testCase.task)}</p>`;
+  }
+
+  return entries
+    .map(
+      ([key, value]) =>
+        `<p class="prompt-input"><strong>${escapeHtml(key)}:</strong> ${escapeMultiline(value)}</p>`,
+    )
+    .join('');
+}
+
+function renderCriteria(criteria: string): string {
+  const lines = criteria
+    .split(/\r?\n|;\s*/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length <= 1) {
+    return escapeMultiline(lines[0] ?? criteria);
+  }
+
+  return lines
+    .map((line) => `<p class="criteria-line">&bull; ${escapeMultiline(line)}</p>`)
+    .join('');
+}
+
+function passCount(results: readonly EvalResult[], passScore: number): number {
+  return results.filter((result) => result.score >= passScore).length;
+}
+
+function percentage(count: number, total: number): number {
+  return total === 0 ? 0 : (count / total) * 100;
+}
+
+function scoreClass(score: number, passScore: number): string {
+  if (score >= passScore) {
+    return 'score-good';
+  }
+
+  if (score >= SCORE_MID_THRESHOLD) {
+    return 'score-mid';
+  }
+
+  return 'score-low';
+}
+
+function formatScore(score: number): string {
+  return Number.isInteger(score) ? String(score) : score.toFixed(1);
+}
+
+function escapeMultiline(value: string): string {
+  return escapeHtml(value).replaceAll('\n', '<br>');
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&': {
+        return '&amp;';
+      }
+
+      case '<': {
+        return '&lt;';
+      }
+
+      case '>': {
+        return '&gt;';
+      }
+
+      case '"': {
+        return '&quot;';
+      }
+
+      case "'": {
+        return '&#39;';
+      }
+
+      default: {
+        return char;
+      }
+    }
+  });
+}

--- a/workspaces/ai-engineering/prompt-eval-lab/src/reports/write-json-report.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/reports/write-json-report.ts
@@ -1,30 +1,9 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { EvalResult, EvalSummary } from '../eval/types.js';
-
-export interface RunMetadata {
-  readonly concurrency: number;
-  readonly datasetPath: string;
-  readonly finishedAt: string;
-  readonly model: string;
-  readonly startedAt: string;
-  readonly templateName: string;
-}
-
-export interface ReportPayload {
-  readonly metadata: RunMetadata;
-  readonly results: readonly EvalResult[];
-  readonly summary: EvalSummary;
-}
+import type { ReportPayload } from './types.js';
 
 export async function writeJsonReport(filePath: string, payload: ReportPayload): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(payload, undefined, 2)}\n`, 'utf8');
-}
-
-export function defaultReportPath(reportsDir: string, now: Date = new Date()): string {
-  const stamp = now.toISOString().replaceAll(':', '-').replaceAll('.', '-');
-
-  return path.join(reportsDir, `${stamp}.json`);
 }

--- a/workspaces/ai-engineering/prompt-eval-lab/src/reports/write-report.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/src/reports/write-report.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+
+import type { ReportFormat, ReportPayload } from './types.js';
+import { writeHtmlReport } from './write-html-report.js';
+import { writeJsonReport } from './write-json-report.js';
+
+export type { ReportFormat, ReportPayload, RunMetadata } from './types.js';
+export { PASS_SCORE } from './write-html-report.js';
+
+export const DEFAULT_REPORT_FORMAT: ReportFormat = 'html';
+
+export async function writeReport(filePath: string, payload: ReportPayload): Promise<ReportFormat> {
+  const format = reportFormatFromPath(filePath);
+
+  if (format === 'html') {
+    await writeHtmlReport(filePath, payload);
+
+    return format;
+  }
+
+  await writeJsonReport(filePath, payload);
+
+  return format;
+}
+
+export function reportFormatFromPath(filePath: string): ReportFormat {
+  const extension = path.extname(filePath).toLowerCase();
+
+  if (extension === '.html') {
+    return 'html';
+  }
+
+  if (extension === '.json') {
+    return 'json';
+  }
+
+  throw new Error(`Unsupported report extension for ${filePath}. Use .html or .json.`);
+}
+
+export function defaultReportPath(
+  reportsDir: string,
+  now: Date = new Date(),
+  format: ReportFormat = DEFAULT_REPORT_FORMAT,
+): string {
+  const stamp = now.toISOString().replaceAll(':', '-').replaceAll('.', '-');
+
+  return path.join(reportsDir, `${stamp}.${format}`);
+}

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/cli/args.test.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/cli/args.test.ts
@@ -64,6 +64,11 @@ describe('parseArgs', () => {
     expect(() => parseArgs(['--dataset=foo.json', '--model='])).toThrow(/--model/);
   });
 
+  it('rejects --out with an unsupported extension', () => {
+    expect(() => parseArgs(['--dataset=foo.json', '--out=report.txt'])).toThrow(/\.html or \.json/);
+    expect(() => parseArgs(['--dataset=foo.json', '--out=report'])).toThrow(/\.html or \.json/);
+  });
+
   it('rejects unknown arguments', () => {
     expect(() => parseArgs(['--dataset=foo.json', '--nope'])).toThrow(/Unknown argument/);
   });

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/cli/run-eval.test.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/cli/run-eval.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockWriteReport = vi.hoisted(() => vi.fn((_path: string) => 'html' as const));
+
+vi.mock('@workspaces/packages/llm-client', () => ({ createProvider: vi.fn(() => ({})) }));
+vi.mock('../../src/config/env.js', () => ({
+  loadConfig: vi.fn(() => ({ model: 'stub-model' })),
+  loadEnvironment: vi.fn(),
+}));
+vi.mock('../../src/datasets/load-dataset.js', () => ({ loadDataset: vi.fn(() => []) }));
+vi.mock('../../src/prompts/templates.js', () => ({
+  DEFAULT_TEMPLATE_NAME: 'code-assistant.v1',
+  isTemplateName: () => true,
+  loadTemplate: vi.fn(() => ''),
+}));
+vi.mock('../../src/eval/runner.js', () => ({
+  DEFAULT_CONCURRENCY: 3,
+  MAX_CONCURRENCY: 10,
+  MIN_CONCURRENCY: 1,
+  runEval: vi.fn(() => []),
+}));
+vi.mock('../../src/reports/write-report.js', () => ({
+  defaultReportPath: (_dir: string, now: Date) =>
+    `reports/${now.toISOString().replaceAll(':', '-')}.html`,
+  PASS_SCORE: 9,
+  writeReport: mockWriteReport,
+}));
+
+import { runEvalCli } from '../../src/cli/run-eval.js';
+
+const BASE_OPTIONS = {
+  concurrency: 3,
+  datasetPath: '/tmp/test.json',
+  templateName: 'code-assistant.v1' as const,
+};
+
+describe('runEvalCli', () => {
+  beforeEach(() => {
+    mockWriteReport.mockClear();
+  });
+
+  it('writes an HTML report to the default path when --out is absent', async () => {
+    const logLines: string[] = [];
+    await runEvalCli(BASE_OPTIONS, { logLine: (l) => logLines.push(l) });
+
+    expect(mockWriteReport).toHaveBeenCalledOnce();
+    expect(mockWriteReport).toHaveBeenCalledWith(
+      expect.stringMatching(/^reports\/.*\.html$/),
+      expect.objectContaining({ passScore: 9 }),
+    );
+    expect(logLines.some((l) => l.includes('HTML'))).toBe(true);
+  });
+
+  it('writes to the explicit --out path when provided', async () => {
+    await runEvalCli({ ...BASE_OPTIONS, outPath: 'custom/out.json' }, {});
+
+    expect(mockWriteReport).toHaveBeenCalledWith(
+      'custom/out.json',
+      expect.objectContaining({ passScore: 9 }),
+    );
+  });
+});

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/datasets/load-dataset.test.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/datasets/load-dataset.test.ts
@@ -22,14 +22,26 @@ describe('loadDataset', () => {
     await writeFile(
       file,
       JSON.stringify([
-        { format: 'json', solution_criteria: 'Returns valid JSON.', task: 'Generate JSON for X.' },
+        {
+          format: 'json',
+          prompt_inputs: { content: 'Extract JSON from this text.' },
+          scenario: 'JSON extraction',
+          solution_criteria: 'Returns valid JSON.',
+          task: 'Generate JSON for X.',
+        },
       ]),
     );
 
     const dataset = await loadDataset(file);
 
     expect(dataset).toEqual([
-      { format: 'json', solution_criteria: 'Returns valid JSON.', task: 'Generate JSON for X.' },
+      {
+        format: 'json',
+        prompt_inputs: { content: 'Extract JSON from this text.' },
+        scenario: 'JSON extraction',
+        solution_criteria: 'Returns valid JSON.',
+        task: 'Generate JSON for X.',
+      },
     ]);
   });
 

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/graders/model-grader.test.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/graders/model-grader.test.ts
@@ -140,10 +140,17 @@ describe('gradeByModel', () => {
 
     expect(modelGraderResultSchema.safeParse({ ...base, score: 1 }).success).toBe(true);
     expect(modelGraderResultSchema.safeParse({ ...base, score: 10 }).success).toBe(true);
+    // Anthropic API rejects minimum/maximum on number types; range is enforced by Zod after parsing.
     expect(GRADER_JSON_SCHEMA).toMatchObject({
       properties: {
-        score: { maximum: 10, minimum: 1, type: 'number' },
+        score: { type: 'number' },
       },
     });
+    expect((GRADER_JSON_SCHEMA.properties as Record<string, unknown>).score).not.toHaveProperty(
+      'minimum',
+    );
+    expect((GRADER_JSON_SCHEMA.properties as Record<string, unknown>).score).not.toHaveProperty(
+      'maximum',
+    );
   });
 });

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/reports/report-fixtures.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/reports/report-fixtures.ts
@@ -1,0 +1,44 @@
+import { summarize } from '../../src/eval/summary.js';
+import type { EvalResult } from '../../src/eval/types.js';
+import { PASS_SCORE } from '../../src/reports/write-report.js';
+import type { ReportPayload } from '../../src/reports/write-report.js';
+
+export function buildPayload(results: EvalResult[] = []): ReportPayload {
+  return {
+    metadata: {
+      concurrency: 3,
+      datasetPath: '/tmp/dataset.json',
+      finishedAt: '2026-05-01T00:00:01Z',
+      model: 'claude-sonnet-4-6',
+      startedAt: '2026-05-01T00:00:00Z',
+      templateName: 'code-assistant.v1',
+    },
+    passScore: PASS_SCORE,
+    results,
+    summary: summarize(results),
+  };
+}
+
+export function makeResult(overrides: Partial<EvalResult> = {}): EvalResult {
+  return {
+    modelGrade: {
+      reasoning: 'Meets the expected shape.',
+      score: 8,
+      strengths: ['Valid'],
+      weaknesses: ['Brief'],
+    },
+    output: '{"ok":true}',
+    score: 9,
+    syntaxScore: 10,
+    testCase: {
+      format: 'json',
+      prompt_inputs: {
+        content: 'Return a JSON object.',
+      },
+      scenario: 'JSON extraction scenario',
+      solution_criteria: 'Returns valid JSON; Includes the ok field',
+      task: 'Return {"ok": true}.',
+    },
+    ...overrides,
+  };
+}

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/reports/write-html-report.test.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/reports/write-html-report.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  PASS_SCORE,
+  renderHtmlReport,
+  writeHtmlReport,
+} from '../../src/reports/write-html-report.js';
+import { buildPayload, makeResult } from './report-fixtures.js';
+
+describe('writeHtmlReport', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'eval-report-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { force: true, recursive: true });
+  });
+
+  it('writes a prompt evaluation report page', async () => {
+    const file = path.join(tempDir, 'nested', 'out.html');
+    await writeHtmlReport(file, buildPayload([makeResult()]));
+
+    const written = await readFile(file, 'utf8');
+
+    expect(written).toContain('<title>Prompt Evaluation Report</title>');
+    expect(written).toContain('Total Test Cases');
+    expect(written).toContain('JSON extraction scenario');
+    expect(written).toContain('<strong>content:</strong>');
+    expect(written).toContain(`Pass Rate (&ge;${PASS_SCORE})`);
+  });
+});
+
+describe('renderHtmlReport', () => {
+  it('escapes model output in the HTML report', () => {
+    const html = renderHtmlReport(
+      buildPayload([
+        makeResult({
+          output: '<script>alert("x")</script>',
+        }),
+      ]),
+    );
+
+    expect(html).toContain('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;');
+    expect(html).not.toContain('<script>alert');
+  });
+
+  it('applies score-good, score-mid, and score-low CSS classes by threshold', () => {
+    const html = renderHtmlReport(
+      buildPayload([makeResult({ score: 9 }), makeResult({ score: 5 }), makeResult({ score: 2 })]),
+    );
+
+    expect(html).toContain('class="badge score-good"');
+    expect(html).toContain('class="badge score-mid"');
+    expect(html).toContain('class="badge score-low"');
+  });
+
+  it('renders 0.0% pass rate and an empty table body for empty results', () => {
+    const html = renderHtmlReport(buildPayload([]));
+
+    expect(html).toContain('0.0%');
+    expect(html).toContain(`Pass Rate (&ge;${PASS_SCORE})`);
+    expect(html).not.toContain('<td>');
+  });
+});

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/reports/write-json-report.test.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/reports/write-json-report.test.ts
@@ -3,35 +3,8 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import type { EvalResult } from '../../src/eval/types.js';
-import {
-  defaultReportPath,
-  type ReportPayload,
-  writeJsonReport,
-} from '../../src/reports/write-json-report.js';
-
-function buildPayload(results: EvalResult[] = []): ReportPayload {
-  return {
-    metadata: {
-      concurrency: 3,
-      datasetPath: '/tmp/dataset.json',
-      finishedAt: '2026-05-01T00:00:01Z',
-      model: 'claude-sonnet-4-6',
-      startedAt: '2026-05-01T00:00:00Z',
-      templateName: 'code-assistant.v1',
-    },
-    results,
-    summary: {
-      averageScore: 0,
-      byFormat: {
-        json: { average: 0, count: 0 },
-        regex: { average: 0, count: 0 },
-        typescript: { average: 0, count: 0 },
-      },
-      total: 0,
-    },
-  };
-}
+import { writeJsonReport } from '../../src/reports/write-json-report.js';
+import { buildPayload } from './report-fixtures.js';
 
 describe('writeJsonReport', () => {
   let tempDir: string;
@@ -61,15 +34,5 @@ describe('writeJsonReport', () => {
     const written = JSON.parse(await readFile(file, 'utf8'));
 
     expect(written).toBeDefined();
-  });
-});
-
-describe('defaultReportPath', () => {
-  it('builds an ISO-stamped path under the reports directory', () => {
-    const filePath = defaultReportPath('/tmp/reports', new Date('2026-05-01T12:34:56.000Z'));
-
-    expect(filePath.startsWith('/tmp/reports/')).toBe(true);
-    expect(filePath.endsWith('.json')).toBe(true);
-    expect(filePath).not.toContain(':');
   });
 });

--- a/workspaces/ai-engineering/prompt-eval-lab/tests/reports/write-report.test.ts
+++ b/workspaces/ai-engineering/prompt-eval-lab/tests/reports/write-report.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  defaultReportPath,
+  reportFormatFromPath,
+  writeReport,
+} from '../../src/reports/write-report.js';
+import { buildPayload, makeResult } from './report-fixtures.js';
+
+describe('writeReport', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'eval-report-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { force: true, recursive: true });
+  });
+
+  it('writes an HTML report for .html paths', async () => {
+    const file = path.join(tempDir, 'out.html');
+    const format = await writeReport(file, buildPayload([makeResult()]));
+
+    const written = await readFile(file, 'utf8');
+
+    expect(format).toBe('html');
+    expect(written).toContain('<title>Prompt Evaluation Report</title>');
+  });
+
+  it('writes a JSON report for .json paths', async () => {
+    const file = path.join(tempDir, 'out.json');
+    const format = await writeReport(file, buildPayload());
+
+    const written = JSON.parse(await readFile(file, 'utf8'));
+
+    expect(format).toBe('json');
+    expect(written.metadata.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('rejects unsupported report extensions', async () => {
+    await expect(writeReport(path.join(tempDir, 'out.htm'), buildPayload())).rejects.toThrow(
+      /\.html or \.json/,
+    );
+  });
+});
+
+describe('defaultReportPath', () => {
+  it('builds an ISO-stamped HTML path under the reports directory by default', () => {
+    const filePath = defaultReportPath('/tmp/reports', new Date('2026-05-01T12:34:56.000Z'));
+
+    expect(filePath.startsWith('/tmp/reports/')).toBe(true);
+    expect(filePath.endsWith('.html')).toBe(true);
+    expect(filePath).not.toContain(':');
+  });
+
+  it('can build a JSON report path', () => {
+    const filePath = defaultReportPath(
+      '/tmp/reports',
+      new Date('2026-05-01T12:34:56.000Z'),
+      'json',
+    );
+
+    expect(filePath.endsWith('.json')).toBe(true);
+  });
+});
+
+describe('reportFormatFromPath', () => {
+  it('supports only .html and .json paths', () => {
+    expect(reportFormatFromPath('reports/run.html')).toBe('html');
+    expect(reportFormatFromPath('reports/run.json')).toBe('json');
+  });
+
+  it('rejects .htm and extensionless paths', () => {
+    expect(() => reportFormatFromPath('reports/run.htm')).toThrow(/\.html or \.json/);
+    expect(() => reportFormatFromPath('reports/run')).toThrow(/\.html or \.json/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a browser-friendly HTML eval report as the default output for
  every run, replacing the old opt-in JSON-only report path.
- Moves the pass-score threshold from a renderer constant into
  `ReportPayload` so it is self-describing and configurable per run.
- Hardens the CLI by validating `--out` extension at parse time and
  fixing an Anthropic API schema rejection that was crashing the grader.

## Motivation

Running the eval with no `--out` flag previously produced no file
output, making it easy to lose results. The grader was also broken at
runtime due to unsupported `minimum`/`maximum` constraints in the
structured-output schema. Both issues blocked normal usage.

## Changes

**Source**
- `src/reports/write-html-report.ts` (new) — HTML renderer with
  score-badge coloring (`score-good`/`score-mid`/`score-low`),
  XSS-safe escaping for all user-controlled fields, responsive CSS, and
  `passScore` + `SCORE_MID_THRESHOLD` constants
- `src/reports/types.ts` (new) — shared `ReportPayload` (now includes
  `passScore: number`), `RunMetadata`, `ReportFormat`
- `src/reports/write-report.ts` (new) — format dispatcher; infers
  `.html`/`.json` from path extension; `defaultReportPath` now defaults
  to `.html`; re-exports `PASS_SCORE`
- `src/reports/write-json-report.ts` — types extracted to `types.ts`;
  `defaultReportPath` moved to `write-report.ts`
- `src/cli/run-eval.ts` — always writes a report; `passScore: PASS_SCORE`
  added to payload; imports updated to `write-report.ts`
- `src/cli/args.ts` — `--out` extension validated via `path.extname`
  before any eval work runs; help text updated
- `src/graders/model-grader.ts` — removes `minimum`/`maximum` from
  grader JSON schema (Anthropic API rejects these for `number` types)
- `src/datasets/types.ts` — optional `scenario` and `prompt_inputs`
  fields added to `TestCase` for richer HTML report rows

**Tests**
- `tests/cli/run-eval.test.ts` (new) — `vi.mock`-based tests verifying
  always-write behavior and explicit `--out` path routing
- `tests/reports/report-fixtures.ts` (new) — shared `buildPayload` /
  `makeResult` helpers used by all report tests
- `tests/reports/write-html-report.test.ts` (new) — file write,
  score-badge class assignment (asserts `class="badge score-good"` not
  just CSS occurrence), empty-result rendering, XSS escaping
- `tests/reports/write-report.test.ts` (new) — format dispatch,
  `defaultReportPath`, `reportFormatFromPath`
- `tests/cli/args.test.ts` — extension rejection test added
- `tests/reports/write-json-report.test.ts` — migrated to shared fixtures
- `tests/graders/model-grader.test.ts` — schema assertions updated

**Docs / config**
- `README.md` — updated CLI options table, added Reports section,
  source map, dataset format example
- `.gitignore` — added `reports/*.html`

## Validation

pnpm --filter prompt-eval-lab test

Test Files 13 passed (13)
Tests 77 passed (77)


TypeScript clean (no new errors introduced).

## Risks

- **JSON report format change (additive):** `passScore` is now
  serialised into `.json` reports. Any automation reading JSON reports
  will see a new field; consumers that ignore unknown fields are
  unaffected.
- **Always-write behavior:** every run now writes to `reports/` by
  default. Environments where `reports/` is not writable will fail.
  The directory is created with `mkdir({ recursive: true })` so it
  does not need to exist, but write permissions are assumed.

## Rollback

Revert this PR. The `reports/` directory and any generated `.html`
files can be deleted safely; they are git-ignored.

## Screenshots / examples

Console output after a successful run:

Running 3 test case(s) with template "code-assistant.v1" against model claude-sonnet-4-6...
...
Wrote HTML report to reports/2026-05-03T12-00-00-000Z.html

## Checklist

- [x] Diff is focused on the prompt-eval-lab workspace only
- [x] 77 tests pass
- [x] Docs and README updated
- [x] No migration required for existing datasets (new fields are optional)
- [x] No secrets or local paths included
- [x] JSON format change is additive and documented under Risks