### PR TITLE
feat(llm-chat): add fine-grained tool streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,17 +93,14 @@ jobs:
   quality:
     name: Lint / Format / Types / Unit
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Enable Corepack (pnpm)
         run: corepack enable
-      - name: Setup Node ${{ matrix.node }}
+      - name: Setup Node 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24.x
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install deps
@@ -125,16 +122,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [24.x]
         workspace: ${{ fromJSON(needs.detect.outputs.workspaces) }}
     steps:
       - uses: actions/checkout@v4
       - name: Enable Corepack (pnpm)
         run: corepack enable
-      - name: Setup Node ${{ matrix.node }}
+      - name: Setup Node 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24.x
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install deps
@@ -153,17 +149,14 @@ jobs:
     needs: [detect, quality]
     if: needs.detect.outputs.root_build == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Enable Corepack (pnpm)
         run: corepack enable
-      - name: Setup Node ${{ matrix.node }}
+      - name: Setup Node 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24.x
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install deps
@@ -176,19 +169,16 @@ jobs:
     needs: quality
     if: always() && ( github.event_name == 'pull_request' || github.ref == 'refs/heads/main' )
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [24.x]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Enable Corepack (pnpm)
         run: corepack enable
-      - name: Setup Node ${{ matrix.node }}
+      - name: Setup Node 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24.x
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install deps

--- a/workspaces/ai-engineering/llm-chat/README.md
+++ b/workspaces/ai-engineering/llm-chat/README.md
@@ -21,6 +21,16 @@ Use `--tools` to enable local Claude tool-use turns. Tool mode is explicit
 because it can make extra model calls. For v1, tool mode cannot be combined
 with `--output-format=*` or `--structured-commands`.
 
+Use `--fine-grained-tool-streaming` together with `--tools` to enable
+Anthropic fine-grained tool streaming. When active, the provider streams
+partial tool input JSON incrementally using `eager_input_streaming: true` on
+each user-defined tool. The app accumulates chunks and only executes the tool
+once the full input JSON is parsed after the `content_block_stop` event.
+Progress is reported through the normal `[tool]` output lines:
+`Streaming input for <tool>` and `Tool input completed`. If the streamed JSON
+is malformed (for example, cut off by `max_tokens`), the tool receives an
+error result and is not executed.
+
 ## Run
 
 Create `.env` in this folder:
@@ -61,6 +71,12 @@ Tool-use mode from the repository root:
 
 ```bash
 pnpm --filter llm-chat dev -- --tools
+```
+
+Fine-grained tool streaming mode:
+
+```bash
+pnpm --filter llm-chat dev -- --tools --fine-grained-tool-streaming
 ```
 
 Example prompts:

--- a/workspaces/ai-engineering/llm-chat/src/chat/service.ts
+++ b/workspaces/ai-engineering/llm-chat/src/chat/service.ts
@@ -3,6 +3,7 @@ import type {
   LlmProvider,
   LlmRequest,
   LlmResponse,
+  LlmToolInputStreamEvent,
   LlmToolResultBlock,
   LlmToolUseBlock,
 } from '@workspaces/packages/llm-client';
@@ -11,7 +12,7 @@ import { executeToolUse } from '../tools/runner.js';
 import { createAppToolExecutionContext } from '../tools/types.js';
 import type { AppTool, AppToolExecutionContext } from '../tools/types.js';
 import { addAssistantContent, addUserMessage, addUserToolResultMessage } from './history.js';
-import type { ChatOptions, Messages } from './types.js';
+import type { ChatOptions, Messages, ToolEventHandler } from './types.js';
 
 export const DEFAULT_MAX_TOKENS = 1000;
 export const DEFAULT_STREAM = true;
@@ -39,6 +40,33 @@ function contentFromResponse(response: LlmResponse): readonly LlmContentBlock[] 
   return response.content ?? [{ text: response.text, type: 'text' }];
 }
 
+function makeToolInputStreamEventHandler(
+  onToolEvent: ToolEventHandler,
+): (event: LlmToolInputStreamEvent) => void {
+  return (event: LlmToolInputStreamEvent) => {
+    switch (event.type) {
+      case 'tool_input_stream_started': {
+        onToolEvent({ toolName: event.name, type: 'tool_input_stream_started' });
+        break;
+      }
+
+      case 'tool_input_stream_completed': {
+        onToolEvent({ toolName: event.name, type: 'tool_input_stream_completed' });
+        break;
+      }
+
+      case 'tool_input_stream_failed': {
+        onToolEvent({ toolName: event.name, type: 'tool_input_stream_failed' });
+        break;
+      }
+
+      default: {
+        break;
+      }
+    }
+  };
+}
+
 export function createChatService(config: ChatServiceConfig): ChatService {
   const defaultMaxTokens = config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
   const tools = config.tools ?? [];
@@ -49,12 +77,21 @@ export function createChatService(config: ChatServiceConfig): ChatService {
     options: ChatOptions,
     toolsEnabled: boolean,
   ): LlmRequest {
+    const fineGrainedToolStreaming = toolsEnabled && options.fineGrainedToolStreaming === true;
+    const streamValue = toolsEnabled
+      ? fineGrainedToolStreaming
+      : (options.stream ?? DEFAULT_STREAM);
+
     return {
       maxTokens: options.maxTokens ?? defaultMaxTokens,
       messages,
       model: config.model,
-      stream: toolsEnabled ? false : (options.stream ?? DEFAULT_STREAM),
+      stream: streamValue,
       ...(toolsEnabled ? { tools: tools.map((tool) => tool.definition) } : {}),
+      ...(fineGrainedToolStreaming ? { fineGrainedToolStreaming: true } : {}),
+      ...(fineGrainedToolStreaming && options.onToolEvent !== undefined
+        ? { onToolInputStreamEvent: makeToolInputStreamEventHandler(options.onToolEvent) }
+        : {}),
       ...(!toolsEnabled && options.onTextDelta ? { onTextDelta: options.onTextDelta } : {}),
       ...(options.outputFormat ? { outputFormat: options.outputFormat } : {}),
       ...(config.systemPrompt ? { systemPrompt: config.systemPrompt } : {}),

--- a/workspaces/ai-engineering/llm-chat/src/chat/types.ts
+++ b/workspaces/ai-engineering/llm-chat/src/chat/types.ts
@@ -8,17 +8,21 @@ export type ToolEvent =
   | { readonly toolName: string; readonly type: 'tool_succeeded' }
   | { readonly toolName: string; readonly type: 'tool_failed' }
   | { readonly count: number; readonly type: 'tool_results_submitted' }
-  | { readonly type: 'final_response_received' };
+  | { readonly type: 'final_response_received' }
+  | { readonly toolName: string; readonly type: 'tool_input_stream_started' }
+  | { readonly toolName: string; readonly type: 'tool_input_stream_completed' }
+  | { readonly toolName: string; readonly type: 'tool_input_stream_failed' };
 
 export type ToolEventHandler = (event: ToolEvent) => void;
 
 export interface ChatOptions {
   debugResponse?: boolean;
+  fineGrainedToolStreaming?: boolean;
   maxTokens?: number;
+  maxToolRounds?: number;
   onTextDelta?: TextDeltaHandler;
   onToolEvent?: ToolEventHandler;
   outputFormat?: OutputFormatConfig;
   stream?: boolean;
   toolsEnabled?: boolean;
-  maxToolRounds?: number;
 }

--- a/workspaces/ai-engineering/llm-chat/src/cli/args.ts
+++ b/workspaces/ai-engineering/llm-chat/src/cli/args.ts
@@ -45,17 +45,18 @@ export interface ParsedArgs {
 
 export function helpText(): string {
   return [
-    'Usage: pnpm dev [--max-tokens=<number>] [--debug-response] [--output-format=json|csv|html] [--tools]',
+    'Usage: pnpm dev [--max-tokens=<number>] [--debug-response] [--output-format=json|csv|html] [--tools] [--fine-grained-tool-streaming]',
     '',
     'Run the LLM chat app.',
     '',
     'Options:',
-    '  --max-tokens=<number>   Maximum number of output tokens per turn.',
-    '  --debug-response        Print the full provider response object.',
-    '  --output-format=<name>   Return a response formatted as json, csv, or html.',
-    '  --structured-commands   Alias for --output-format=json.',
-    '  --tools                 Enable local app tools for Claude tool-use turns.',
-    '  -h, --help              Show this help message.',
+    '  --max-tokens=<number>          Maximum number of output tokens per turn.',
+    '  --debug-response               Print the full provider response object.',
+    '  --output-format=<name>         Return a response formatted as json, csv, or html.',
+    '  --structured-commands          Alias for --output-format=json.',
+    '  --tools                        Enable local app tools for Claude tool-use turns.',
+    '  --fine-grained-tool-streaming  Stream tool input JSON incrementally (requires --tools).',
+    '  -h, --help                     Show this help message.',
   ].join('\n');
 }
 
@@ -78,6 +79,11 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
 
     if (argument === '--tools') {
       options.toolsEnabled = true;
+      continue;
+    }
+
+    if (argument === '--fine-grained-tool-streaming') {
+      options.fineGrainedToolStreaming = true;
       continue;
     }
 
@@ -107,6 +113,10 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
 
   if (options.toolsEnabled === true && options.outputFormat !== undefined) {
     throw new Error('--tools cannot be combined with --output-format or --structured-commands.');
+  }
+
+  if (options.fineGrainedToolStreaming === true && options.toolsEnabled !== true) {
+    throw new Error('--fine-grained-tool-streaming requires --tools.');
   }
 
   return { options, shouldPrintHelp: false };

--- a/workspaces/ai-engineering/llm-chat/src/cli/run-chatbot.ts
+++ b/workspaces/ai-engineering/llm-chat/src/cli/run-chatbot.ts
@@ -11,6 +11,7 @@ export type TurnRunner = (
 
 export interface RunChatbotOptions {
   readonly debugResponse?: boolean;
+  readonly fineGrainedToolStreaming?: boolean;
   readonly input: InputFunction;
   readonly maxTokens?: number;
   readonly output?: OutputFunction;
@@ -44,6 +45,18 @@ function formatToolEvent(event: ToolEvent): string {
       : '[tool] Sending tool results to Claude';
   }
 
+  if (event.type === 'tool_input_stream_started') {
+    return `[tool] Streaming input for ${event.toolName}`;
+  }
+
+  if (event.type === 'tool_input_stream_completed') {
+    return '[tool] Tool input completed';
+  }
+
+  if (event.type === 'tool_input_stream_failed') {
+    return '[tool] Tool input streaming failed';
+  }
+
   return '[tool] Final response received';
 }
 
@@ -74,7 +87,10 @@ export async function runChatbot(options: RunChatbotOptions): Promise<Messages> 
       chatOptions.debugResponse = options.debugResponse;
     }
 
-    chatOptions.stream = options.toolsEnabled === true ? false : (options.stream ?? true);
+    const fineGrainedToolStreaming =
+      options.toolsEnabled === true && options.fineGrainedToolStreaming === true;
+    chatOptions.stream =
+      options.toolsEnabled === true ? fineGrainedToolStreaming : (options.stream ?? true);
 
     if (options.outputFormat) {
       chatOptions.outputFormat = options.outputFormat;
@@ -82,6 +98,10 @@ export async function runChatbot(options: RunChatbotOptions): Promise<Messages> 
 
     if (options.toolsEnabled === true) {
       chatOptions.toolsEnabled = true;
+
+      if (fineGrainedToolStreaming) {
+        chatOptions.fineGrainedToolStreaming = true;
+      }
 
       chatOptions.onToolEvent = (event) => {
         output(formatToolEvent(event));

--- a/workspaces/ai-engineering/llm-chat/src/tools/runner.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/runner.ts
@@ -33,6 +33,10 @@ export async function executeToolUse(
   tools: readonly AppTool[],
   context: AppToolExecutionContext,
 ): Promise<LlmToolResultBlock> {
+  if (toolUse.inputError !== undefined) {
+    return createErrorResult(toolUse.id, toolUse.inputError.message);
+  }
+
   const tool = findToolByName(tools, toolUse.name);
 
   if (tool === undefined) {

--- a/workspaces/ai-engineering/llm-chat/tests/chat/service.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/chat/service.test.ts
@@ -3,6 +3,7 @@ import type {
   LlmProvider,
   LlmRequest,
   LlmResponse,
+  LlmToolInputStreamEvent,
 } from '@workspaces/packages/llm-client';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -336,6 +337,127 @@ describe('chat service', () => {
       ],
       role: 'user',
     });
+  });
+
+  it('uses stream: false for normal tool turns', async () => {
+    const messages: Messages = [];
+    const tool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'echo' },
+      execute: () => ({}),
+    };
+    const { calls, provider } = createSequenceProvider([
+      { content: [{ text: 'done', type: 'text' }], raw: {}, stopReason: 'end_turn', text: 'done' },
+    ]);
+
+    const service = createChatService({ model: DEFAULT_MODEL, provider, tools: [tool] });
+    await service.sendUserTurn(messages, 'hi', { toolsEnabled: true });
+
+    expect(calls[0]).toMatchObject({ stream: false });
+  });
+
+  it('uses stream: true and passes fineGrainedToolStreaming when flag is set', async () => {
+    const messages: Messages = [];
+    const tool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'echo' },
+      execute: () => ({}),
+    };
+    const { calls, provider } = createSequenceProvider([
+      { content: [{ text: 'done', type: 'text' }], raw: {}, stopReason: 'end_turn', text: 'done' },
+    ]);
+
+    const service = createChatService({ model: DEFAULT_MODEL, provider, tools: [tool] });
+    await service.sendUserTurn(messages, 'hi', {
+      fineGrainedToolStreaming: true,
+      toolsEnabled: true,
+    });
+
+    expect(calls[0]).toMatchObject({ fineGrainedToolStreaming: true, stream: true });
+  });
+
+  it('maps LlmToolInputStreamEvent to ToolEvent via onToolEvent handler', async () => {
+    const messages: Messages = [];
+    const events: ToolEvent[] = [];
+    const tool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'echo' },
+      execute: () => ({}),
+    };
+    let capturedStreamEventHandler: ((e: LlmToolInputStreamEvent) => void) | undefined;
+    const provider: LlmProvider = {
+      createMessage(request) {
+        capturedStreamEventHandler = request.onToolInputStreamEvent;
+
+        return Promise.resolve({
+          content: [{ text: 'done', type: 'text' }],
+          raw: {},
+          stopReason: 'end_turn',
+          text: 'done',
+        });
+      },
+    };
+
+    const service = createChatService({ model: DEFAULT_MODEL, provider, tools: [tool] });
+    await service.sendUserTurn(messages, 'hi', {
+      fineGrainedToolStreaming: true,
+      onToolEvent: (e) => events.push(e),
+      toolsEnabled: true,
+    });
+
+    capturedStreamEventHandler?.({ name: 'echo', type: 'tool_input_stream_started' } as const);
+    capturedStreamEventHandler?.({ name: 'echo', type: 'tool_input_stream_completed' } as const);
+    capturedStreamEventHandler?.({ name: 'echo', type: 'tool_input_stream_failed' } as const);
+
+    expect(events).toContainEqual({ toolName: 'echo', type: 'tool_input_stream_started' });
+    expect(events).toContainEqual({ toolName: 'echo', type: 'tool_input_stream_completed' });
+    expect(events).toContainEqual({ toolName: 'echo', type: 'tool_input_stream_failed' });
+  });
+
+  it('returns an error tool_result and does not execute the tool when inputError is set', async () => {
+    const messages: Messages = [];
+    const tool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'echo' },
+      execute: vi.fn(),
+    };
+    const { provider } = createSequenceProvider([
+      {
+        content: [
+          {
+            id: 'toolu_bad',
+            input: {},
+            inputError: {
+              code: 'invalid_json',
+              message: 'Invalid tool input JSON received from provider.',
+            },
+            name: 'echo',
+            type: 'tool_use',
+          },
+        ],
+        raw: {},
+        stopReason: 'tool_use',
+        text: '',
+      },
+      {
+        content: [{ text: 'recovered', type: 'text' }],
+        raw: {},
+        stopReason: 'end_turn',
+        text: 'recovered',
+      },
+    ]);
+
+    const service = createChatService({ model: DEFAULT_MODEL, provider, tools: [tool] });
+    await service.sendUserTurn(messages, 'hi', { toolsEnabled: true });
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    const toolResultMessage = messages[2];
+    expect(toolResultMessage).toBeDefined();
+
+    if (toolResultMessage !== undefined && typeof toolResultMessage.content !== 'string') {
+      const resultBlock = toolResultMessage.content[0];
+      expect(resultBlock).toMatchObject({
+        is_error: true,
+        tool_use_id: 'toolu_bad',
+        type: 'tool_result',
+      });
+    }
   });
 
   it('enforces the max tool round guard', async () => {

--- a/workspaces/ai-engineering/llm-chat/tests/cli/args.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/cli/args.test.ts
@@ -67,6 +67,17 @@ describe('parseArgs', () => {
     expect(() => parseArgs(['--structured-commands', '--tools'])).toThrow(/cannot be combined/);
   });
 
+  it('parses --fine-grained-tool-streaming with --tools', () => {
+    expect(parseArgs(['--tools', '--fine-grained-tool-streaming'])).toEqual({
+      options: { fineGrainedToolStreaming: true, toolsEnabled: true },
+      shouldPrintHelp: false,
+    });
+  });
+
+  it('rejects --fine-grained-tool-streaming without --tools', () => {
+    expect(() => parseArgs(['--fine-grained-tool-streaming'])).toThrow(/requires --tools/);
+  });
+
   it('ignores the forwarded pnpm delimiter', () => {
     expect(parseArgs(['--', '--output-format=json']).options.outputFormat).toEqual({
       instructions:
@@ -91,7 +102,7 @@ describe('parseArgs', () => {
 });
 
 describe('helpText', () => {
-  it('mentions both flags', () => {
+  it('mentions all flags', () => {
     const text = helpText();
 
     expect(text).toContain('--max-tokens');
@@ -99,5 +110,6 @@ describe('helpText', () => {
     expect(text).toContain('--output-format');
     expect(text).toContain('--structured-commands');
     expect(text).toContain('--tools');
+    expect(text).toContain('--fine-grained-tool-streaming');
   });
 });

--- a/workspaces/ai-engineering/llm-chat/tests/cli/run-chatbot.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/cli/run-chatbot.test.ts
@@ -161,4 +161,55 @@ describe('runChatbot', () => {
       '',
     ]);
   });
+
+  it('passes fineGrainedToolStreaming and renders streaming progress events', async () => {
+    const outputs: string[] = [];
+    const userInputs = ['What time is it?'];
+
+    await runChatbot({
+      fineGrainedToolStreaming: true,
+      input: () => {
+        const nextInput = userInputs.shift();
+
+        if (nextInput === undefined) {
+          throw new Error('No more input');
+        }
+
+        return Promise.resolve(nextInput);
+      },
+      output: (text) => {
+        outputs.push(text);
+      },
+      runTurn: (messages, text, options) => {
+        expect(options.stream).toBe(true);
+        expect(options.toolsEnabled).toBe(true);
+        expect(options.fineGrainedToolStreaming).toBe(true);
+        expect(options.onTextDelta).toBeUndefined();
+        expect(options.onToolEvent).toEqual(expect.any(Function));
+
+        addUserMessage(messages, text);
+        options.onToolEvent?.({
+          toolName: 'get_current_datetime',
+          type: 'tool_input_stream_started',
+        });
+        options.onToolEvent?.({
+          toolName: 'get_current_datetime',
+          type: 'tool_input_stream_completed',
+        });
+        options.onToolEvent?.({
+          toolName: 'get_current_datetime',
+          type: 'tool_input_stream_failed',
+        });
+        options.onToolEvent?.({ type: 'final_response_received' });
+        addAssistantMessage(messages, 'It is noon.');
+
+        return Promise.resolve('It is noon.');
+      },
+      toolsEnabled: true,
+    });
+
+    expect(outputs).toContain('[tool] Streaming input for get_current_datetime');
+    expect(outputs).toContain('[tool] Tool input completed');
+    expect(outputs).toContain('[tool] Tool input streaming failed');
+  });
 });

--- a/workspaces/ai-engineering/llm-chat/tests/tools/runner.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/tools/runner.test.ts
@@ -47,6 +47,39 @@ describe('tool runner', () => {
     });
   });
 
+  it('returns an error result and does not execute the tool when inputError is set', async () => {
+    const tool: AppTool = {
+      definition: {
+        inputSchema: { type: 'object' },
+        name: 'echo_tool',
+      },
+      execute: vi.fn(),
+    };
+
+    const result = await executeToolUse(
+      {
+        id: 'toolu_bad',
+        input: {},
+        inputError: {
+          code: 'invalid_json',
+          message: 'Invalid tool input JSON received from provider.',
+        },
+        name: 'echo_tool',
+        type: 'tool_use',
+      },
+      [tool],
+      context,
+    );
+
+    expect(tool.execute).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: '{"error":"Invalid tool input JSON received from provider."}',
+      is_error: true,
+      tool_use_id: 'toolu_bad',
+      type: 'tool_result',
+    });
+  });
+
   it('returns a sanitized error result for thrown validation errors', async () => {
     const tool: AppTool = {
       definition: {

--- a/workspaces/packages/llm-client/src/anthropic/messages-api.ts
+++ b/workspaces/packages/llm-client/src/anthropic/messages-api.ts
@@ -12,10 +12,12 @@ import type {
   LlmProvider,
   LlmRequest,
   LlmResponse,
+  LlmTextBlock,
   LlmToolDefinition,
   LlmToolInputSchema,
 } from '../types.js';
 import { textFromMessage } from './text.js';
+import { accumulateToolInputStream } from './tool-input-stream.js';
 
 function toAnthropicInputSchema(schema: LlmToolInputSchema): Tool.InputSchema {
   const { required, ...rest } = schema;
@@ -26,12 +28,16 @@ function toAnthropicInputSchema(schema: LlmToolInputSchema): Tool.InputSchema {
   } as Tool.InputSchema;
 }
 
-export function toAnthropicTools(tools: readonly LlmToolDefinition[]): Tool[] {
+export function toAnthropicTools(
+  tools: readonly LlmToolDefinition[],
+  eagerInputStreaming = false,
+): Tool[] {
   return tools.map((tool) => ({
     input_schema: toAnthropicInputSchema(tool.inputSchema),
     name: tool.name,
     ...(tool.description === undefined ? {} : { description: tool.description }),
     ...(tool.inputExamples === undefined ? {} : { input_examples: [...tool.inputExamples] }),
+    ...(eagerInputStreaming ? { eager_input_streaming: true as const } : {}),
   }));
 }
 
@@ -103,6 +109,13 @@ function createLlmResponse(message: Message, text: string): LlmResponse {
   };
 }
 
+function textFromBlocks(blocks: readonly LlmContentBlock[]): string {
+  return blocks
+    .filter((b): b is LlmTextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n');
+}
+
 export function createAnthropicProvider(client: Anthropic): LlmProvider {
   return {
     async createMessage(request: LlmRequest): Promise<LlmResponse> {
@@ -120,6 +133,12 @@ export function createAnthropicProvider(client: Anthropic): LlmProvider {
         requestMessages.push({ content: assistantPrefill, role: 'assistant' });
       }
 
+      const streamEnabled = request.stream ?? true;
+      const useFineGrainedStreaming =
+        streamEnabled &&
+        request.fineGrainedToolStreaming === true &&
+        (request.tools?.length ?? 0) > 0;
+
       const params = {
         max_tokens: request.maxTokens,
         messages: requestMessages,
@@ -129,13 +148,43 @@ export function createAnthropicProvider(client: Anthropic): LlmProvider {
           : {}),
         ...(system ? { system } : {}),
         ...(request.temperature === undefined ? {} : { temperature: request.temperature }),
-        ...(request.tools?.length ? { tools: toAnthropicTools(request.tools) } : {}),
+        ...(request.tools?.length
+          ? { tools: toAnthropicTools(request.tools, useFineGrainedStreaming) }
+          : {}),
         ...(jsonSchema === undefined
           ? {}
           : { output_config: { format: { schema: jsonSchema, type: 'json_schema' as const } } }),
       };
 
-      if (request.stream ?? true) {
+      if (useFineGrainedStreaming) {
+        if (assistantPrefill && request.onTextDelta) {
+          request.onTextDelta(assistantPrefill);
+        }
+
+        const stream = client.messages.stream(params);
+        const { blocks, stopReason } = await accumulateToolInputStream(
+          stream,
+          request.onTextDelta,
+          request.onToolInputStreamEvent,
+        );
+        const rawMessage = await stream.finalMessage();
+        const text = `${assistantPrefill}${textFromBlocks(blocks)}${responseSuffix}`;
+
+        if (responseSuffix && request.onTextDelta) {
+          request.onTextDelta(responseSuffix);
+        }
+
+        const resolvedStopReason = stopReason ?? rawMessage.stop_reason ?? undefined;
+
+        return {
+          content: blocks,
+          raw: rawMessage,
+          ...(resolvedStopReason === undefined ? {} : { stopReason: resolvedStopReason }),
+          text,
+        };
+      }
+
+      if (streamEnabled) {
         const stream = client.messages.stream(params);
 
         if (assistantPrefill && request.onTextDelta) {

--- a/workspaces/packages/llm-client/src/anthropic/tool-input-stream.ts
+++ b/workspaces/packages/llm-client/src/anthropic/tool-input-stream.ts
@@ -18,6 +18,7 @@ interface ToolUseState {
 }
 
 interface UnknownState {
+  deltas: unknown[];
   raw: unknown;
   type: 'unknown';
 }
@@ -53,7 +54,7 @@ export async function accumulateToolInputStream(
           });
           onToolInputStreamEvent?.({ name: content_block.name, type: 'tool_input_stream_started' });
         } else {
-          blockStates.set(index, { raw: content_block, type: 'unknown' });
+          blockStates.set(index, { deltas: [], raw: content_block, type: 'unknown' });
         }
 
         break;
@@ -67,6 +68,8 @@ export async function accumulateToolInputStream(
           onTextDelta?.(event.delta.text);
         } else if (state?.type === 'tool_use' && event.delta.type === 'input_json_delta') {
           state.jsonBuffer += event.delta.partial_json;
+        } else if (state?.type === 'unknown') {
+          state.deltas.push(event.delta);
         }
 
         break;
@@ -142,7 +145,7 @@ export async function accumulateToolInputStream(
         });
       }
     } else {
-      blocks.push({ raw: state.raw, type: 'unknown' });
+      blocks.push({ raw: { block: state.raw, deltas: state.deltas }, type: 'unknown' });
     }
   }
 

--- a/workspaces/packages/llm-client/src/anthropic/tool-input-stream.ts
+++ b/workspaces/packages/llm-client/src/anthropic/tool-input-stream.ts
@@ -1,0 +1,150 @@
+import type { MessageStreamEvent } from '@anthropic-ai/sdk/resources/messages/messages';
+
+import type { LlmContentBlock, LlmToolInputStreamEvent } from '../types.js';
+
+interface TextState {
+  buffer: string;
+  type: 'text';
+}
+
+interface ToolUseState {
+  id: string;
+  jsonBuffer: string;
+  name: string;
+  parseError?: true;
+  parsed?: unknown;
+  stopped?: true;
+  type: 'tool_use';
+}
+
+interface UnknownState {
+  raw: unknown;
+  type: 'unknown';
+}
+
+type BlockState = TextState | ToolUseState | UnknownState;
+
+export interface ToolStreamAccumulation {
+  readonly blocks: readonly LlmContentBlock[];
+  readonly stopReason: string | undefined;
+}
+
+export async function accumulateToolInputStream(
+  stream: AsyncIterable<MessageStreamEvent>,
+  onTextDelta?: (text: string) => void,
+  onToolInputStreamEvent?: (event: LlmToolInputStreamEvent) => void,
+): Promise<ToolStreamAccumulation> {
+  const blockStates = new Map<number, BlockState>();
+  let stopReason: string | undefined;
+
+  for await (const event of stream) {
+    switch (event.type) {
+      case 'content_block_start': {
+        const { content_block, index } = event;
+
+        if (content_block.type === 'text') {
+          blockStates.set(index, { buffer: '', type: 'text' });
+        } else if (content_block.type === 'tool_use') {
+          blockStates.set(index, {
+            id: content_block.id,
+            jsonBuffer: '',
+            name: content_block.name,
+            type: 'tool_use',
+          });
+          onToolInputStreamEvent?.({ name: content_block.name, type: 'tool_input_stream_started' });
+        } else {
+          blockStates.set(index, { raw: content_block, type: 'unknown' });
+        }
+
+        break;
+      }
+
+      case 'content_block_delta': {
+        const state = blockStates.get(event.index);
+
+        if (state?.type === 'text' && event.delta.type === 'text_delta') {
+          state.buffer += event.delta.text;
+          onTextDelta?.(event.delta.text);
+        } else if (state?.type === 'tool_use' && event.delta.type === 'input_json_delta') {
+          state.jsonBuffer += event.delta.partial_json;
+        }
+
+        break;
+      }
+
+      case 'content_block_stop': {
+        const state = blockStates.get(event.index);
+
+        if (state?.type === 'tool_use') {
+          state.stopped = true;
+          const rawJson = state.jsonBuffer.trim();
+
+          try {
+            state.parsed = rawJson === '' ? {} : (JSON.parse(rawJson) as unknown);
+            onToolInputStreamEvent?.({ name: state.name, type: 'tool_input_stream_completed' });
+          } catch {
+            state.parseError = true;
+            onToolInputStreamEvent?.({ name: state.name, type: 'tool_input_stream_failed' });
+          }
+        }
+
+        break;
+      }
+
+      case 'message_delta': {
+        stopReason = event.delta.stop_reason ?? undefined;
+        break;
+      }
+
+      default: {
+        break;
+      }
+    }
+  }
+
+  for (const state of blockStates.values()) {
+    if (state.type === 'tool_use' && state.stopped !== true && state.parseError !== true) {
+      state.parseError = true;
+      onToolInputStreamEvent?.({ name: state.name, type: 'tool_input_stream_failed' });
+    }
+  }
+
+  const blocks: LlmContentBlock[] = [];
+  const sortedIndices = [...blockStates.keys()].toSorted((a, b) => a - b);
+
+  for (const index of sortedIndices) {
+    const state = blockStates.get(index);
+
+    if (state === undefined) {
+      continue;
+    }
+
+    if (state.type === 'text') {
+      blocks.push({ text: state.buffer, type: 'text' });
+    } else if (state.type === 'tool_use') {
+      if (state.parseError === true) {
+        blocks.push({
+          id: state.id,
+          input: {},
+          inputError: {
+            code: 'invalid_json',
+            message: 'Invalid tool input JSON received from provider.',
+          },
+          name: state.name,
+          type: 'tool_use',
+        });
+      } else {
+        blocks.push({
+          id: state.id,
+          input: state.parsed ?? {},
+          name: state.name,
+          type: 'tool_use',
+        });
+      }
+    } else {
+      blocks.push({ raw: state.raw, type: 'unknown' });
+    }
+  }
+
+  return { blocks, stopReason };
+}

--- a/workspaces/packages/llm-client/src/index.ts
+++ b/workspaces/packages/llm-client/src/index.ts
@@ -13,6 +13,7 @@ export type {
   LlmTextBlock,
   LlmToolDefinition,
   LlmToolInputSchema,
+  LlmToolInputStreamEvent,
   LlmToolResultBlock,
   LlmToolUseBlock,
   LlmUnknownBlock,

--- a/workspaces/packages/llm-client/src/types.ts
+++ b/workspaces/packages/llm-client/src/types.ts
@@ -6,8 +6,17 @@ export interface LlmTextBlock {
 export interface LlmToolUseBlock {
   readonly id: string;
   readonly input: unknown;
+  readonly inputError?: { readonly code: 'invalid_json'; readonly message: string };
   readonly name: string;
   readonly type: 'tool_use';
+}
+
+export interface LlmToolInputStreamEvent {
+  readonly name: string;
+  readonly type:
+    | 'tool_input_stream_started'
+    | 'tool_input_stream_completed'
+    | 'tool_input_stream_failed';
 }
 
 export interface LlmToolResultBlock {
@@ -56,10 +65,12 @@ export interface OutputFormatConfig {
 }
 
 export interface LlmRequest {
+  readonly fineGrainedToolStreaming?: boolean;
   readonly maxTokens: number;
   readonly messages: Messages;
   readonly model: string;
   readonly onTextDelta?: TextDeltaHandler;
+  readonly onToolInputStreamEvent?: (event: LlmToolInputStreamEvent) => void;
   readonly outputFormat?: OutputFormatConfig;
   readonly stream?: boolean;
   readonly systemPrompt?: string;

--- a/workspaces/packages/llm-client/tests/anthropic/messages-api.test.ts
+++ b/workspaces/packages/llm-client/tests/anthropic/messages-api.test.ts
@@ -344,4 +344,123 @@ describe('createAnthropicProvider', () => {
     ).rejects.toThrow(/unknown content block/);
     expect(create).not.toHaveBeenCalled();
   });
+
+  it('includes eager_input_streaming on tools when fineGrainedToolStreaming is enabled', async () => {
+    const events: Anthropic.Messages.MessageStreamEvent[] = [
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: {},
+          name: 'get_current_datetime',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{"format":"iso"}', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+      {
+        delta: {
+          container: null,
+          stop_details: null,
+          stop_reason: 'tool_use',
+          stop_sequence: null,
+        },
+        type: 'message_delta',
+        usage: { output_tokens: 10 },
+      },
+      { type: 'message_stop' },
+    ] as unknown as Anthropic.Messages.MessageStreamEvent[];
+
+    const finalMessage = vi.fn().mockResolvedValue({
+      content: [
+        {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: { format: 'iso' },
+          name: 'get_current_datetime',
+          type: 'tool_use',
+        },
+      ],
+      stop_reason: 'tool_use',
+    });
+
+    let capturedParams: unknown;
+    const stream = vi.fn().mockImplementation((params) => {
+      capturedParams = params;
+
+      return {
+        finalMessage,
+        [Symbol.asyncIterator]() {
+          let i = 0;
+
+          return {
+            next() {
+              const event = events[i++];
+
+              return Promise.resolve(
+                event === undefined
+                  ? { done: true as const, value: undefined }
+                  : { done: false, value: event },
+              );
+            },
+          };
+        },
+      };
+    });
+    const client = { messages: { stream } } as unknown as Anthropic;
+
+    const provider = createAnthropicProvider(client);
+    const response = await provider.createMessage({
+      fineGrainedToolStreaming: true,
+      maxTokens: 100,
+      messages: [{ content: 'What time is it?', role: 'user' }],
+      model: DEFAULT_MODEL,
+      tools: [
+        {
+          description: 'Get the current date and time.',
+          inputSchema: { type: 'object' },
+          name: 'get_current_datetime',
+        },
+      ],
+    });
+
+    expect(response.content).toEqual([
+      { id: 'toolu_1', input: { format: 'iso' }, name: 'get_current_datetime', type: 'tool_use' },
+    ]);
+    expect(response.stopReason).toBe('tool_use');
+    expect(capturedParams).toMatchObject({
+      tools: [
+        expect.objectContaining({ eager_input_streaming: true, name: 'get_current_datetime' }),
+      ],
+    });
+  });
+
+  it('does not include eager_input_streaming on tools when fineGrainedToolStreaming is not enabled', async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ id: 'toolu_1', input: {}, name: 'my_tool', type: 'tool_use' }],
+      stop_reason: 'tool_use',
+    });
+    const client = { messages: { create } } as unknown as Anthropic;
+
+    const provider = createAnthropicProvider(client);
+    await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: DEFAULT_MODEL,
+      stream: false,
+      tools: [{ inputSchema: { type: 'object' }, name: 'my_tool' }],
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [expect.not.objectContaining({ eager_input_streaming: true })],
+      }),
+    );
+  });
 });

--- a/workspaces/packages/llm-client/tests/anthropic/tool-input-stream.test.ts
+++ b/workspaces/packages/llm-client/tests/anthropic/tool-input-stream.test.ts
@@ -1,0 +1,396 @@
+import type { MessageStreamEvent } from '@anthropic-ai/sdk/resources/messages/messages';
+import { describe, expect, it, vi } from 'vitest';
+
+import { accumulateToolInputStream } from '../../src/anthropic/tool-input-stream.js';
+import type { LlmToolInputStreamEvent } from '../../src/types.js';
+
+function makeStream(events: MessageStreamEvent[]): AsyncIterable<MessageStreamEvent> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+
+      return {
+        next() {
+          const event = events[index++];
+
+          return Promise.resolve(
+            event === undefined
+              ? { done: true as const, value: undefined }
+              : { done: false, value: event },
+          );
+        },
+      };
+    },
+  };
+}
+
+describe('accumulateToolInputStream', () => {
+  it('accumulates multiple input_json_delta chunks into a single tool_use block', async () => {
+    const stream = makeStream([
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: {},
+          name: 'get_current_datetime',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{"for', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      {
+        delta: { partial_json: 'mat":"iso"}', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+      {
+        delta: {
+          container: null,
+          stop_details: null,
+          stop_reason: 'tool_use',
+          stop_sequence: null,
+        },
+        type: 'message_delta',
+        usage: { output_tokens: 10 },
+      },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks, stopReason } = await accumulateToolInputStream(stream);
+
+    expect(blocks).toEqual([
+      { id: 'toolu_1', input: { format: 'iso' }, name: 'get_current_datetime', type: 'tool_use' },
+    ]);
+    expect(stopReason).toBe('tool_use');
+  });
+
+  it('tracks multiple tool-use blocks separately by content block index', async () => {
+    const stream = makeStream([
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: {},
+          name: 'tool_a',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_2',
+          input: {},
+          name: 'tool_b',
+          type: 'tool_use',
+        },
+        index: 1,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{"x":1}', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      {
+        delta: { partial_json: '{"y":2}', type: 'input_json_delta' },
+        index: 1,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+      { index: 1, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks } = await accumulateToolInputStream(stream);
+
+    expect(blocks).toEqual([
+      { id: 'toolu_1', input: { x: 1 }, name: 'tool_a', type: 'tool_use' },
+      { id: 'toolu_2', input: { y: 2 }, name: 'tool_b', type: 'tool_use' },
+    ]);
+  });
+
+  it('creates a safe invalid-input marker when JSON is malformed and exposes no raw JSON in message', async () => {
+    const stream = makeStream([
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_bad',
+          input: {},
+          name: 'bad_tool',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{not valid', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks } = await accumulateToolInputStream(stream);
+
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(block?.type).toBe('tool_use');
+
+    if (block?.type === 'tool_use') {
+      expect(block.inputError).toEqual({
+        code: 'invalid_json',
+        message: 'Invalid tool input JSON received from provider.',
+      });
+      expect(block.input).toEqual({});
+      expect(JSON.stringify(block.inputError)).not.toContain('not valid');
+    }
+  });
+
+  it('creates a safe invalid-input marker when a tool-use block never stops', async () => {
+    const events: LlmToolInputStreamEvent[] = [];
+    const stream = makeStream([
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_cutoff',
+          input: {},
+          name: 'cutoff_tool',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{"format":"iso"', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      {
+        delta: {
+          container: null,
+          stop_details: null,
+          stop_reason: 'tool_use',
+          stop_sequence: null,
+        },
+        type: 'message_delta',
+        usage: { output_tokens: 10 },
+      },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks, stopReason } = await accumulateToolInputStream(stream, undefined, (event) => {
+      events.push(event);
+    });
+
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(block?.type).toBe('tool_use');
+
+    if (block?.type === 'tool_use') {
+      expect(block.inputError).toEqual({
+        code: 'invalid_json',
+        message: 'Invalid tool input JSON received from provider.',
+      });
+      expect(block.input).toEqual({});
+      expect(JSON.stringify(block.inputError)).not.toContain('format');
+    }
+
+    expect(stopReason).toBe('tool_use');
+    expect(events).toEqual([
+      { name: 'cutoff_tool', type: 'tool_input_stream_started' },
+      { name: 'cutoff_tool', type: 'tool_input_stream_failed' },
+    ]);
+  });
+
+  it('fires tool_input_stream_started and tool_input_stream_completed events', async () => {
+    const events: LlmToolInputStreamEvent[] = [];
+    const stream = makeStream([
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: {},
+          name: 'my_tool',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{}', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    await accumulateToolInputStream(stream, undefined, (event) => {
+      events.push(event);
+    });
+
+    expect(events).toEqual([
+      { name: 'my_tool', type: 'tool_input_stream_started' },
+      { name: 'my_tool', type: 'tool_input_stream_completed' },
+    ]);
+  });
+
+  it('fires tool_input_stream_failed when JSON is invalid', async () => {
+    const events: LlmToolInputStreamEvent[] = [];
+    const stream = makeStream([
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: {},
+          name: 'bad_tool',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{broken', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    await accumulateToolInputStream(stream, undefined, (event) => {
+      events.push(event);
+    });
+
+    expect(events).toEqual([
+      { name: 'bad_tool', type: 'tool_input_stream_started' },
+      { name: 'bad_tool', type: 'tool_input_stream_failed' },
+    ]);
+  });
+
+  it('accumulates text deltas and calls onTextDelta for each chunk', async () => {
+    const chunks: string[] = [];
+    const stream = makeStream([
+      { content_block: { text: '', type: 'text' }, index: 0, type: 'content_block_start' },
+      { delta: { text: 'Hello ', type: 'text_delta' }, index: 0, type: 'content_block_delta' },
+      { delta: { text: 'world', type: 'text_delta' }, index: 0, type: 'content_block_delta' },
+      { index: 0, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks } = await accumulateToolInputStream(stream, (text) => {
+      chunks.push(text);
+    });
+
+    expect(blocks).toEqual([{ text: 'Hello world', type: 'text' }]);
+    expect(chunks).toEqual(['Hello ', 'world']);
+  });
+
+  it('preserves unknown content blocks as unknown type', async () => {
+    const thinkingBlock = { signature: 'sig', thinking: 'reasoning...', type: 'thinking' };
+    const stream = makeStream([
+      { content_block: thinkingBlock, index: 0, type: 'content_block_start' },
+      { index: 0, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks } = await accumulateToolInputStream(stream);
+
+    expect(blocks).toEqual([{ raw: thinkingBlock, type: 'unknown' }]);
+  });
+
+  it('includes parsed tool_use blocks, text blocks, and stopReason in the result', async () => {
+    const stream = makeStream([
+      { content_block: { text: '', type: 'text' }, index: 0, type: 'content_block_start' },
+      {
+        delta: { text: 'Let me check.', type: 'text_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: {},
+          name: 'get_time',
+          type: 'tool_use',
+        },
+        index: 1,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{"tz":"UTC"}', type: 'input_json_delta' },
+        index: 1,
+        type: 'content_block_delta',
+      },
+      { index: 1, type: 'content_block_stop' },
+      {
+        delta: {
+          container: null,
+          stop_details: null,
+          stop_reason: 'tool_use',
+          stop_sequence: null,
+        },
+        type: 'message_delta',
+        usage: { output_tokens: 5 },
+      },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks, stopReason } = await accumulateToolInputStream(stream);
+
+    expect(blocks).toEqual([
+      { text: 'Let me check.', type: 'text' },
+      { id: 'toolu_1', input: { tz: 'UTC' }, name: 'get_time', type: 'tool_use' },
+    ]);
+    expect(stopReason).toBe('tool_use');
+  });
+
+  it('ignores unknown event types gracefully', async () => {
+    const onToolEvent = vi.fn();
+    const stream = makeStream([
+      {
+        message: {
+          content: [],
+          id: 'msg_1',
+          model: 'm',
+          role: 'assistant',
+          stop_reason: null,
+          stop_sequence: null,
+          type: 'message',
+          usage: {
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+          },
+        },
+        type: 'message_start',
+      },
+      {
+        content_block: {
+          caller: { type: 'direct' },
+          id: 'toolu_1',
+          input: {},
+          name: 'tool_x',
+          type: 'tool_use',
+        },
+        index: 0,
+        type: 'content_block_start',
+      },
+      {
+        delta: { partial_json: '{"ok":true}', type: 'input_json_delta' },
+        index: 0,
+        type: 'content_block_delta',
+      },
+      { index: 0, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks } = await accumulateToolInputStream(stream, undefined, onToolEvent);
+
+    expect(blocks).toEqual([
+      { id: 'toolu_1', input: { ok: true }, name: 'tool_x', type: 'tool_use' },
+    ]);
+  });
+});

--- a/workspaces/packages/llm-client/tests/anthropic/tool-input-stream.test.ts
+++ b/workspaces/packages/llm-client/tests/anthropic/tool-input-stream.test.ts
@@ -288,7 +288,7 @@ describe('accumulateToolInputStream', () => {
     expect(chunks).toEqual(['Hello ', 'world']);
   });
 
-  it('preserves unknown content blocks as unknown type', async () => {
+  it('preserves unknown content blocks as { block, deltas } with an empty deltas array when no deltas arrive', async () => {
     const thinkingBlock = { signature: 'sig', thinking: 'reasoning...', type: 'thinking' };
     const stream = makeStream([
       { content_block: thinkingBlock, index: 0, type: 'content_block_start' },
@@ -297,7 +297,25 @@ describe('accumulateToolInputStream', () => {
 
     const { blocks } = await accumulateToolInputStream(stream);
 
-    expect(blocks).toEqual([{ raw: thinkingBlock, type: 'unknown' }]);
+    expect(blocks).toEqual([{ raw: { block: thinkingBlock, deltas: [] }, type: 'unknown' }]);
+  });
+
+  it('accumulates raw deltas for unknown blocks so no stream data is dropped', async () => {
+    const startBlock = { thinking: '', type: 'thinking' };
+    const thinkingDelta = { thinking: 'step 1', type: 'thinking_delta' };
+    const signatureDelta = { signature: 'ABC123', type: 'signature_delta' };
+    const stream = makeStream([
+      { content_block: startBlock, index: 0, type: 'content_block_start' },
+      { delta: thinkingDelta, index: 0, type: 'content_block_delta' },
+      { delta: signatureDelta, index: 0, type: 'content_block_delta' },
+      { index: 0, type: 'content_block_stop' },
+    ] as unknown as MessageStreamEvent[]);
+
+    const { blocks } = await accumulateToolInputStream(stream);
+
+    expect(blocks).toEqual([
+      { raw: { block: startBlock, deltas: [thinkingDelta, signatureDelta] }, type: 'unknown' },
+    ]);
   });
 
   it('includes parsed tool_use blocks, text blocks, and stopReason in the result', async () => {


### PR DESCRIPTION
- add opt-in --fine-grained-tool-streaming for Claude tool turns
- enable Anthropic eager_input_streaming and accumulate streamed tool input JSON
- convert malformed or incomplete tool input streams into safe error tool results
- surface provider-neutral tool input progress events in the CLI
- cover adapter, parser, CLI, tool runner, and truncated-stream cases with tests