### PR TITLE
feat(llm-chat): add Anthropic text editor tool with workspace path safety

### DIFF
--- a/workspaces/ai-engineering/llm-chat/README.md
+++ b/workspaces/ai-engineering/llm-chat/README.md
@@ -79,6 +79,18 @@ Fine-grained tool streaming mode:
 pnpm --filter llm-chat dev -- --tools --fine-grained-tool-streaming
 ```
 
+Anthropic Text Editor Tool mode (file editing is opt-in):
+
+```bash
+pnpm --filter llm-chat dev -- --tools --edit-files --workspace-root=.
+```
+
+Optional max characters for `view`:
+
+```bash
+pnpm --filter llm-chat dev -- --tools --edit-files --text-editor-max-characters=10000
+```
+
 Example prompts:
 
 - `What is the exact current time?`
@@ -102,6 +114,54 @@ Tool progress lines use the `[tool]` prefix. `--debug-response` still prints raw
 provider responses and should be treated as developer-only output, especially
 with sensitive prompts.
 
+## Anthropic Text Editor Tool
+
+`--edit-files` enables Anthropic's
+[`text_editor_20250728`](https://platform.claude.com/docs/en/agents-and-tools/tool-use/text-editor-tool)
+client tool, named `str_replace_based_edit_tool`. The tool definition is
+schema-less — Claude knows the schema internally — and the application owns
+all file-system execution. The tool is rejected unless `--tools` is also set.
+
+The runtime supports four commands:
+
+- `view` - reads a file with line-numbered output, optional `view_range`, and
+  optional `max_characters` truncation, or lists a directory non-recursively.
+- `create` - writes a new file under the allowed workspace root. Refuses to
+  overwrite an existing file.
+- `str_replace` - replaces exactly one occurrence of `old_str`. Errors when
+  `old_str` matches zero or more than one time.
+- `insert` - inserts `insert_text` after `insert_line` (1-indexed; `0` inserts
+  at the beginning of the file).
+
+`undo_edit` is intentionally not supported. Restore from
+`.llm-chat-edit-backups/<relative-path>` if needed. Backups are written before
+every `str_replace` and `insert`.
+
+### Security model
+
+- `--workspace-root=<path>` (default: `process.cwd()`) bounds every file
+  operation. Paths are normalized against the root and rejected when they
+  escape via `..`, absolute paths, or symbolic links.
+- Hidden paths (segments starting with `.`) are blocked by default. `.env` and
+  `.env.*` files stay blocked even when hidden paths are otherwise allowed.
+- `node_modules`, `.git`, and the backup directory are blocked.
+- Binary and non-UTF-8 files are rejected.
+- `view` enforces a max readable byte size; write operations enforce a max
+  editable byte size and return a clear `tool_result` error when exceeded.
+- Errors are returned as `tool_result` blocks with `is_error: true` and
+  sanitized messages. Stack traces, raw old/new strings, and absolute paths
+  outside the workspace root are not echoed back to Claude.
+
+### Limitations
+
+- v1 does not support `undo_edit`, deletes, renames, chmod, or shell
+  execution.
+- v1 rejects `--fine-grained-tool-streaming` together with `--edit-files`
+  because per-tool `eager_input_streaming` is documented as user-defined-tool
+  only.
+- v1 does not include per-operation user confirmation. The `--edit-files`
+  flag is the explicit opt-in for the entire session.
+
 The system prompt and temperature are currently hardcoded in `src/main.ts` as `SYSTEM_PROMPT` and `TEMPERATURE`.
 
 ## Source Map
@@ -110,5 +170,6 @@ The system prompt and temperature are currently hardcoded in `src/main.ts` as `S
 - `src/config/env.ts` - app-local `.env` path wrapper around the shared config loader.
 - `src/cli/` - argument parsing, readline input adapter, interactive loop.
 - `src/chat/` - chat types, message history helpers, chat service that orchestrates a turn.
-- `src/tools/` - app-local tool registry, runner, and mock tool implementations.
+- `src/tools/` - app-local tool registry, runner, mock tool implementations, and the
+  Anthropic Text Editor runtime under `src/tools/text-editor/`.
 - `../../packages/llm-client/src/` - provider-neutral types, config loader, provider factory, and Anthropic SDK adapter.

--- a/workspaces/ai-engineering/llm-chat/src/chat/service.ts
+++ b/workspaces/ai-engineering/llm-chat/src/chat/service.ts
@@ -3,12 +3,14 @@ import type {
   LlmProvider,
   LlmRequest,
   LlmResponse,
+  LlmToolDefinition,
   LlmToolInputStreamEvent,
   LlmToolResultBlock,
   LlmToolUseBlock,
 } from '@workspaces/packages/llm-client';
 
 import { executeToolUse } from '../tools/runner.js';
+import type { ClientToolRuntime } from '../tools/runner.js';
 import { createAppToolExecutionContext } from '../tools/types.js';
 import type { AppTool, AppToolExecutionContext } from '../tools/types.js';
 import { addAssistantContent, addUserMessage, addUserToolResultMessage } from './history.js';
@@ -18,7 +20,13 @@ export const DEFAULT_MAX_TOKENS = 1000;
 export const DEFAULT_STREAM = true;
 export const DEFAULT_MAX_TOOL_ROUNDS = 5;
 
+export interface BuiltinClientTool {
+  readonly definition: LlmToolDefinition;
+  readonly runtime: ClientToolRuntime;
+}
+
 export interface ChatServiceConfig {
+  readonly builtinClientTools?: readonly BuiltinClientTool[];
   readonly defaultMaxTokens?: number;
   readonly model: string;
   readonly provider: LlmProvider;
@@ -70,7 +78,16 @@ function makeToolInputStreamEventHandler(
 export function createChatService(config: ChatServiceConfig): ChatService {
   const defaultMaxTokens = config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
   const tools = config.tools ?? [];
+  const builtinClientTools = config.builtinClientTools ?? [];
+  const clientRuntimes = builtinClientTools.map((tool) => tool.runtime);
   const toolContext = config.toolContext ?? createAppToolExecutionContext();
+
+  function buildToolDefinitions(): readonly LlmToolDefinition[] {
+    const customDefinitions = tools.map((tool) => tool.definition);
+    const builtinDefinitions = builtinClientTools.map((tool) => tool.definition);
+
+    return [...customDefinitions, ...builtinDefinitions];
+  }
 
   function createRequest(
     messages: Messages,
@@ -87,7 +104,7 @@ export function createChatService(config: ChatServiceConfig): ChatService {
       messages,
       model: config.model,
       stream: streamValue,
-      ...(toolsEnabled ? { tools: tools.map((tool) => tool.definition) } : {}),
+      ...(toolsEnabled ? { tools: buildToolDefinitions() } : {}),
       ...(fineGrainedToolStreaming ? { fineGrainedToolStreaming: true } : {}),
       ...(fineGrainedToolStreaming && options.onToolEvent !== undefined
         ? { onToolInputStreamEvent: makeToolInputStreamEventHandler(options.onToolEvent) }
@@ -158,7 +175,7 @@ export function createChatService(config: ChatServiceConfig): ChatService {
         for (const toolUse of toolUseBlocks) {
           options.onToolEvent?.({ toolName: toolUse.name, type: 'tool_running' });
 
-          const result = await executeToolUse(toolUse, tools, toolContext);
+          const result = await executeToolUse(toolUse, tools, toolContext, clientRuntimes);
 
           options.onToolEvent?.({
             toolName: toolUse.name,

--- a/workspaces/ai-engineering/llm-chat/src/cli/args.ts
+++ b/workspaces/ai-engineering/llm-chat/src/cli/args.ts
@@ -2,6 +2,15 @@ import type { OutputFormatConfig } from '@workspaces/packages/llm-client';
 
 import type { ChatOptions } from '../chat/types.js';
 
+export interface EditFilesConfig {
+  readonly textEditorMaxCharacters?: number;
+  readonly workspaceRoot?: string;
+}
+
+export interface ParsedOptions extends ChatOptions {
+  editFiles?: EditFilesConfig;
+}
+
 export const OUTPUT_FORMAT_PRESETS = {
   csv: {
     instructions:
@@ -39,29 +48,45 @@ function parseOutputFormat(value: string): OutputFormatConfig {
 }
 
 export interface ParsedArgs {
-  readonly options: ChatOptions;
+  readonly options: ParsedOptions;
   readonly shouldPrintHelp: boolean;
 }
 
 export function helpText(): string {
   return [
-    'Usage: pnpm dev [--max-tokens=<number>] [--debug-response] [--output-format=json|csv|html] [--tools] [--fine-grained-tool-streaming]',
+    'Usage: pnpm dev [--max-tokens=<number>] [--debug-response] [--output-format=json|csv|html] [--tools] [--fine-grained-tool-streaming] [--edit-files] [--workspace-root=<path>] [--text-editor-max-characters=<number>]',
     '',
     'Run the LLM chat app.',
     '',
     'Options:',
-    '  --max-tokens=<number>          Maximum number of output tokens per turn.',
-    '  --debug-response               Print the full provider response object.',
-    '  --output-format=<name>         Return a response formatted as json, csv, or html.',
-    '  --structured-commands          Alias for --output-format=json.',
-    '  --tools                        Enable local app tools for Claude tool-use turns.',
-    '  --fine-grained-tool-streaming  Stream tool input JSON incrementally (requires --tools).',
-    '  -h, --help                     Show this help message.',
+    '  --max-tokens=<number>                 Maximum number of output tokens per turn.',
+    '  --debug-response                      Print the full provider response object.',
+    '  --output-format=<name>                Return a response formatted as json, csv, or html.',
+    '  --structured-commands                 Alias for --output-format=json.',
+    '  --tools                               Enable local app tools for Claude tool-use turns.',
+    '  --fine-grained-tool-streaming         Stream tool input JSON incrementally (requires --tools).',
+    '  --edit-files                          Enable Anthropic Text Editor Tool (requires --tools).',
+    '  --workspace-root=<path>               Allowed filesystem root for --edit-files (default: current working directory).',
+    '  --text-editor-max-characters=<number> Optional max characters for view operations.',
+    '  -h, --help                            Show this help message.',
   ].join('\n');
 }
 
+function parsePositiveInteger(raw: string, flag: string): number {
+  const value = Number(raw);
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${flag} must be a positive integer.`);
+  }
+
+  return value;
+}
+
 export function parseArgs(argv: readonly string[]): ParsedArgs {
-  const options: ChatOptions = {};
+  const options: ParsedOptions = {};
+  let editFilesEnabled = false;
+  let workspaceRoot: string | undefined;
+  let textEditorMaxCharacters: number | undefined;
 
   for (const argument of argv) {
     if (argument === '--') {
@@ -87,6 +112,11 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       continue;
     }
 
+    if (argument === '--edit-files') {
+      editFilesEnabled = true;
+      continue;
+    }
+
     if (argument === '--structured-commands') {
       options.outputFormat = OUTPUT_FORMAT_PRESETS.json;
       continue;
@@ -98,13 +128,29 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
     }
 
     if (argument.startsWith('--max-tokens=')) {
-      const value = Number(argument.slice('--max-tokens='.length));
+      options.maxTokens = parsePositiveInteger(
+        argument.slice('--max-tokens='.length),
+        '--max-tokens',
+      );
+      continue;
+    }
 
-      if (!Number.isInteger(value) || value <= 0) {
-        throw new Error('--max-tokens must be a positive integer.');
+    if (argument.startsWith('--workspace-root=')) {
+      const value = argument.slice('--workspace-root='.length);
+
+      if (value === '') {
+        throw new Error('--workspace-root must be a non-empty path.');
       }
 
-      options.maxTokens = value;
+      workspaceRoot = value;
+      continue;
+    }
+
+    if (argument.startsWith('--text-editor-max-characters=')) {
+      textEditorMaxCharacters = parsePositiveInteger(
+        argument.slice('--text-editor-max-characters='.length),
+        '--text-editor-max-characters',
+      );
       continue;
     }
 
@@ -117,6 +163,29 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
 
   if (options.fineGrainedToolStreaming === true && options.toolsEnabled !== true) {
     throw new Error('--fine-grained-tool-streaming requires --tools.');
+  }
+
+  if (editFilesEnabled && options.toolsEnabled !== true) {
+    throw new Error('--edit-files requires --tools.');
+  }
+
+  if (editFilesEnabled && options.fineGrainedToolStreaming === true) {
+    throw new Error('--edit-files cannot be combined with --fine-grained-tool-streaming in v1.');
+  }
+
+  if (!editFilesEnabled && workspaceRoot !== undefined) {
+    throw new Error('--workspace-root requires --edit-files.');
+  }
+
+  if (!editFilesEnabled && textEditorMaxCharacters !== undefined) {
+    throw new Error('--text-editor-max-characters requires --edit-files.');
+  }
+
+  if (editFilesEnabled) {
+    options.editFiles = {
+      ...(textEditorMaxCharacters === undefined ? {} : { textEditorMaxCharacters }),
+      ...(workspaceRoot === undefined ? {} : { workspaceRoot }),
+    };
   }
 
   return { options, shouldPrintHelp: false };

--- a/workspaces/ai-engineering/llm-chat/src/main.ts
+++ b/workspaces/ai-engineering/llm-chat/src/main.ts
@@ -2,17 +2,35 @@ import { createProvider } from '@workspaces/packages/llm-client';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import type { BuiltinClientTool } from './chat/service.js';
 import { createChatService } from './chat/service.js';
 import { helpText, parseArgs } from './cli/args.js';
+import type { EditFilesConfig } from './cli/args.js';
 import { createReadlineInput } from './cli/readline.js';
 import { runChatbot } from './cli/run-chatbot.js';
 import { loadConfig, loadEnvironment } from './config/env.js';
 import { llmChatTools } from './tools/registry.js';
+import { createTextEditorRuntime } from './tools/text-editor/index.js';
 import { createAppToolExecutionContext } from './tools/types.js';
 
-const SYSTEM_PROMPT = 'Answer as shortly as possible.';
+const SYSTEM_PROMPT_BASE = 'Answer as shortly as possible.';
 const TEMPERATURE = 0.2;
 const STREAM = true;
+
+function buildBuiltinClientTools(editFiles: EditFilesConfig): {
+  builtinClientTools: BuiltinClientTool[];
+  workspaceRoot: string;
+} {
+  const workspaceRoot = path.resolve(editFiles.workspaceRoot ?? process.cwd());
+  const runtime = createTextEditorRuntime({
+    workspaceRoot,
+    ...(editFiles.textEditorMaxCharacters === undefined
+      ? {}
+      : { maxViewCharacters: editFiles.textEditorMaxCharacters }),
+  });
+
+  return { builtinClientTools: [{ definition: runtime.definition, runtime }], workspaceRoot };
+}
 
 async function main(): Promise<void> {
   const parsedArgs = parseArgs(process.argv.slice(2));
@@ -26,10 +44,18 @@ async function main(): Promise<void> {
   loadEnvironment();
   const config = loadConfig();
   const provider = createProvider(config);
+  const { editFiles, ...chatOptions } = parsedArgs.options;
+  const editFilesResult = editFiles === undefined ? undefined : buildBuiltinClientTools(editFiles);
+  const builtinClientTools = editFilesResult?.builtinClientTools ?? [];
+  const systemPrompt =
+    editFilesResult === undefined
+      ? SYSTEM_PROMPT_BASE
+      : `${SYSTEM_PROMPT_BASE} File editing workspace root: "${editFilesResult.workspaceRoot}". Always use paths relative to this root (e.g. "src/main.ts") or absolute paths that start with this root.`;
   const chatService = createChatService({
+    builtinClientTools,
     model: config.model,
     provider,
-    systemPrompt: SYSTEM_PROMPT,
+    systemPrompt,
     temperature: TEMPERATURE,
     toolContext: createAppToolExecutionContext(),
     tools: llmChatTools,
@@ -39,7 +65,7 @@ async function main(): Promise<void> {
 
   try {
     await runChatbot({
-      ...parsedArgs.options,
+      ...chatOptions,
       input: (prompt) => input.ask(prompt),
       runTurn: (messages, text, options) => chatService.sendUserTurn(messages, text, options),
       stream: STREAM,

--- a/workspaces/ai-engineering/llm-chat/src/tools/runner.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/runner.ts
@@ -5,6 +5,11 @@ import type { AppTool, AppToolExecutionContext } from './types.js';
 
 const MAX_ERROR_MESSAGE_LENGTH = 200;
 
+export interface ClientToolRuntime {
+  readonly toolName: string;
+  execute(toolUse: LlmToolUseBlock): Promise<LlmToolResultBlock>;
+}
+
 function sanitizeError(error: unknown): string {
   const message =
     error instanceof Error && error.message.trim() !== ''
@@ -28,11 +33,25 @@ function createErrorResult(toolUseId: string, message: string): LlmToolResultBlo
   };
 }
 
+function findClientRuntime(
+  runtimes: readonly ClientToolRuntime[],
+  name: string,
+): ClientToolRuntime | undefined {
+  return runtimes.find((runtime) => runtime.toolName === name);
+}
+
 export async function executeToolUse(
   toolUse: LlmToolUseBlock,
   tools: readonly AppTool[],
   context: AppToolExecutionContext,
+  clientRuntimes: readonly ClientToolRuntime[] = [],
 ): Promise<LlmToolResultBlock> {
+  const clientRuntime = findClientRuntime(clientRuntimes, toolUse.name);
+
+  if (clientRuntime !== undefined) {
+    return clientRuntime.execute(toolUse);
+  }
+
   if (toolUse.inputError !== undefined) {
     return createErrorResult(toolUse.id, toolUse.inputError.message);
   }

--- a/workspaces/ai-engineering/llm-chat/src/tools/runner.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/runner.ts
@@ -49,7 +49,11 @@ export async function executeToolUse(
   const clientRuntime = findClientRuntime(clientRuntimes, toolUse.name);
 
   if (clientRuntime !== undefined) {
-    return clientRuntime.execute(toolUse);
+    try {
+      return await clientRuntime.execute(toolUse);
+    } catch (error) {
+      return createErrorResult(toolUse.id, sanitizeError(error));
+    }
   }
 
   if (toolUse.inputError !== undefined) {

--- a/workspaces/ai-engineering/llm-chat/src/tools/text-editor/index.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/text-editor/index.ts
@@ -1,0 +1,13 @@
+export { parseTextEditorInput, TextEditorInputError } from './input.js';
+export { createTextEditorRuntime } from './runtime.js';
+export {
+  createTextEditorToolDefinition,
+  TEXT_EDITOR_TOOL_NAME,
+  TEXT_EDITOR_TOOL_TYPE,
+} from './types.js';
+export type {
+  TextEditorCommand,
+  TextEditorRuntime,
+  TextEditorRuntimeConfig,
+  TextEditorToolInput,
+} from './types.js';

--- a/workspaces/ai-engineering/llm-chat/src/tools/text-editor/input.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/text-editor/input.ts
@@ -1,0 +1,107 @@
+import type { TextEditorToolInput } from './types.js';
+
+export class TextEditorInputError extends Error {
+  readonly code = 'invalid_input';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'TextEditorInputError';
+  }
+}
+
+function asRecord(input: unknown): Record<string, unknown> {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TextEditorInputError('Tool input must be a JSON object.');
+  }
+
+  return input as Record<string, unknown>;
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new TextEditorInputError(`${field} must be a string.`);
+  }
+
+  return value;
+}
+
+function requireInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new TextEditorInputError(`${field} must be an integer.`);
+  }
+
+  return value;
+}
+
+function parseViewRange(value: unknown): readonly [number, number] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value) || value.length !== 2) {
+    throw new TextEditorInputError('view_range must be a [start, end] array of two integers.');
+  }
+
+  const start = requireInteger(value[0], 'view_range[0]');
+  const end = requireInteger(value[1], 'view_range[1]');
+
+  if (start < 1) {
+    throw new TextEditorInputError('view_range[0] must be a positive integer.');
+  }
+
+  if (end !== -1 && end < start) {
+    throw new TextEditorInputError('view_range[1] must be >= view_range[0] or -1 for end of file.');
+  }
+
+  return [start, end] as const;
+}
+
+export function parseTextEditorInput(rawInput: unknown): TextEditorToolInput {
+  const record = asRecord(rawInput);
+  const command = requireString(record.command, 'command');
+
+  if (command === 'view') {
+    const filePath = requireString(record.path, 'path');
+    const viewRange = parseViewRange(record.view_range);
+
+    return viewRange === undefined
+      ? { command: 'view', path: filePath }
+      : { command: 'view', path: filePath, view_range: viewRange };
+  }
+
+  if (command === 'create') {
+    const filePath = requireString(record.path, 'path');
+    const fileText = requireString(record.file_text, 'file_text');
+
+    return { command: 'create', file_text: fileText, path: filePath };
+  }
+
+  if (command === 'str_replace') {
+    const filePath = requireString(record.path, 'path');
+    const oldStr = requireString(record.old_str, 'old_str');
+    const newStr = requireString(record.new_str, 'new_str');
+
+    return { command: 'str_replace', new_str: newStr, old_str: oldStr, path: filePath };
+  }
+
+  if (command === 'insert') {
+    const filePath = requireString(record.path, 'path');
+    const insertLine = requireInteger(record.insert_line, 'insert_line');
+
+    if (insertLine < 0) {
+      throw new TextEditorInputError('insert_line must be >= 0.');
+    }
+
+    const insertText = requireString(record.insert_text, 'insert_text');
+
+    return { command: 'insert', insert_line: insertLine, insert_text: insertText, path: filePath };
+  }
+
+  if (command === 'undo_edit') {
+    throw new TextEditorInputError(
+      'undo_edit is not supported. Restore from .llm-chat-edit-backups manually if needed.',
+    );
+  }
+
+  throw new TextEditorInputError(`Unknown command: ${command}.`);
+}

--- a/workspaces/ai-engineering/llm-chat/src/tools/text-editor/operations.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/text-editor/operations.ts
@@ -1,0 +1,367 @@
+import { copyFile, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { ResolvedPath } from './path-safety.js';
+
+export class TextEditorOperationError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = 'TextEditorOperationError';
+  }
+}
+
+const DEFAULT_MAX_VIEW_BYTES = 256 * 1024;
+const DEFAULT_MAX_EDITABLE_BYTES = 1024 * 1024;
+const BINARY_SCAN_BYTE_LIMIT = 8 * 1024;
+
+export interface OperationLimits {
+  readonly maxEditableBytes: number;
+  readonly maxViewBytes: number;
+  readonly maxViewCharacters?: number;
+}
+
+export function resolveLimits(config: Partial<OperationLimits> | undefined): OperationLimits {
+  return {
+    maxEditableBytes: config?.maxEditableBytes ?? DEFAULT_MAX_EDITABLE_BYTES,
+    maxViewBytes: config?.maxViewBytes ?? DEFAULT_MAX_VIEW_BYTES,
+    ...(config?.maxViewCharacters === undefined
+      ? {}
+      : { maxViewCharacters: config.maxViewCharacters }),
+  };
+}
+
+function looksBinary(buffer: Buffer): boolean {
+  const length = Math.min(buffer.length, BINARY_SCAN_BYTE_LIMIT);
+
+  for (let i = 0; i < length; i += 1) {
+    const byte = buffer[i];
+
+    if (byte === 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isUtf8(buffer: Buffer): boolean {
+  try {
+    const decoder = new TextDecoder('utf-8', { fatal: true });
+    decoder.decode(buffer);
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectLineEnding(text: string): '\r\n' | '\n' {
+  return text.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function splitLinesPreserveEmptyTrailing(text: string): string[] {
+  if (text === '') {
+    return [];
+  }
+
+  return text.split(/\r\n|\n/);
+}
+
+function joinLines(lines: readonly string[], lineEnding: string): string {
+  return lines.join(lineEnding);
+}
+
+function formatLineNumberedView(text: string, startLine: number): string {
+  const lines = splitLinesPreserveEmptyTrailing(text);
+  const lastLine = startLine + lines.length - 1;
+  const width = String(Math.max(lastLine, startLine)).length;
+
+  return lines
+    .map((line, index) => {
+      const number = String(startLine + index).padStart(width, ' ');
+
+      return `${number}\t${line}`;
+    })
+    .join('\n');
+}
+
+export interface ViewOptions {
+  readonly limits: OperationLimits;
+  readonly resolved: ResolvedPath;
+  readonly viewRange?: readonly [number, number];
+}
+
+export interface ViewResult {
+  readonly content: string;
+  readonly truncated: boolean;
+}
+
+async function viewDirectory(absolutePath: string): Promise<ViewResult> {
+  const entries = await readdir(absolutePath, { withFileTypes: true });
+  const lines = entries
+    .filter((entry) => !entry.name.startsWith('.'))
+    .toSorted((a, b) => a.name.localeCompare(b.name))
+    .map((entry) => `${entry.isDirectory() ? 'd' : '-'} ${entry.name}`);
+
+  return { content: lines.join('\n'), truncated: false };
+}
+
+async function viewFile(options: ViewOptions): Promise<ViewResult> {
+  const { absolutePath } = options.resolved;
+  const limits = options.limits;
+  const stats = await stat(absolutePath);
+
+  if (stats.size > limits.maxViewBytes) {
+    throw new TextEditorOperationError(
+      'file_too_large',
+      `File is too large to view (size ${stats.size} bytes, limit ${limits.maxViewBytes}).`,
+    );
+  }
+
+  const buffer = await readFile(absolutePath);
+
+  if (looksBinary(buffer) || !isUtf8(buffer)) {
+    throw new TextEditorOperationError(
+      'binary_file',
+      'Binary or non-UTF-8 files are not supported.',
+    );
+  }
+
+  const text = buffer.toString('utf8');
+  const lines = splitLinesPreserveEmptyTrailing(text);
+  let startIndex = 0;
+  let endIndex = lines.length;
+
+  if (options.viewRange !== undefined) {
+    const [rangeStart, rangeEnd] = options.viewRange;
+
+    if (rangeStart > lines.length) {
+      throw new TextEditorOperationError(
+        'view_range_out_of_bounds',
+        `view_range[0]=${rangeStart} is beyond file length ${lines.length}.`,
+      );
+    }
+
+    startIndex = rangeStart - 1;
+    endIndex = rangeEnd === -1 ? lines.length : Math.min(rangeEnd, lines.length);
+  }
+
+  const slice = lines.slice(startIndex, endIndex);
+  const sliceText = slice.join('\n');
+  let truncated = false;
+  let displayText = sliceText;
+
+  if (limits.maxViewCharacters !== undefined && displayText.length > limits.maxViewCharacters) {
+    displayText = displayText.slice(0, limits.maxViewCharacters);
+    truncated = true;
+  }
+
+  const numbered = formatLineNumberedView(displayText, startIndex + 1);
+  const suffix = truncated ? '\n[truncated]' : '';
+
+  return { content: `${numbered}${suffix}`, truncated };
+}
+
+export async function viewPath(options: ViewOptions): Promise<ViewResult> {
+  const stats = await stat(options.resolved.absolutePath).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new TextEditorOperationError('not_found', 'Path does not exist.');
+    }
+
+    throw error;
+  });
+
+  if (stats.isDirectory()) {
+    return viewDirectory(options.resolved.absolutePath);
+  }
+
+  if (!stats.isFile()) {
+    throw new TextEditorOperationError(
+      'unsupported_target',
+      'Only regular files and directories are supported.',
+    );
+  }
+
+  return viewFile(options);
+}
+
+export async function createFile(
+  resolved: ResolvedPath,
+  fileText: string,
+  limits: OperationLimits,
+): Promise<void> {
+  if (Buffer.byteLength(fileText, 'utf8') > limits.maxEditableBytes) {
+    throw new TextEditorOperationError(
+      'file_too_large',
+      `New file content exceeds the editable byte limit of ${limits.maxEditableBytes}.`,
+    );
+  }
+
+  await mkdir(path.dirname(resolved.absolutePath), { recursive: true });
+
+  try {
+    await writeFile(resolved.absolutePath, fileText, { encoding: 'utf8', flag: 'wx' });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new TextEditorOperationError(
+        'file_exists',
+        'create cannot overwrite an existing file.',
+      );
+    }
+
+    throw error;
+  }
+}
+
+export interface BackupContext {
+  readonly backupRoot: string;
+  readonly relativeFromRoot: string;
+}
+
+async function snapshotFile(resolved: ResolvedPath, context: BackupContext): Promise<string> {
+  const target = path.resolve(context.backupRoot, context.relativeFromRoot);
+  await mkdir(path.dirname(target), { recursive: true });
+  await copyFile(resolved.absolutePath, target);
+
+  return target;
+}
+
+async function readUtf8File(resolved: ResolvedPath, limits: OperationLimits): Promise<string> {
+  const stats = await stat(resolved.absolutePath).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new TextEditorOperationError('not_found', 'Path does not exist.');
+    }
+
+    throw error;
+  });
+
+  if (!stats.isFile()) {
+    throw new TextEditorOperationError('unsupported_target', 'Only regular files can be edited.');
+  }
+
+  if (stats.size > limits.maxEditableBytes) {
+    throw new TextEditorOperationError(
+      'file_too_large',
+      `File is too large to edit (size ${stats.size} bytes, limit ${limits.maxEditableBytes}).`,
+    );
+  }
+
+  const buffer = await readFile(resolved.absolutePath);
+
+  if (looksBinary(buffer) || !isUtf8(buffer)) {
+    throw new TextEditorOperationError(
+      'binary_file',
+      'Binary or non-UTF-8 files are not supported for editing.',
+    );
+  }
+
+  return buffer.toString('utf8');
+}
+
+export interface StrReplaceArgs {
+  readonly backup: BackupContext;
+  readonly limits: OperationLimits;
+  readonly newStr: string;
+  readonly oldStr: string;
+  readonly resolved: ResolvedPath;
+}
+
+export interface StrReplaceResult {
+  readonly backupPath: string;
+}
+
+function countOccurrences(text: string, search: string): number {
+  if (search === '') {
+    throw new TextEditorOperationError('invalid_input', 'old_str must not be empty.');
+  }
+
+  let count = 0;
+  let cursor = 0;
+
+  while (true) {
+    const next = text.indexOf(search, cursor);
+
+    if (next === -1) {
+      return count;
+    }
+
+    count += 1;
+    cursor = next + search.length;
+  }
+}
+
+export async function strReplace(args: StrReplaceArgs): Promise<StrReplaceResult> {
+  const original = await readUtf8File(args.resolved, args.limits);
+  const matches = countOccurrences(original, args.oldStr);
+
+  if (matches === 0) {
+    throw new TextEditorOperationError('no_match', 'old_str was not found in the file.');
+  }
+
+  if (matches > 1) {
+    throw new TextEditorOperationError(
+      'multiple_matches',
+      `old_str matched ${matches} times; expected exactly one match.`,
+    );
+  }
+
+  const backupPath = await snapshotFile(args.resolved, args.backup);
+  const updated = original.replace(args.oldStr, args.newStr);
+
+  if (Buffer.byteLength(updated, 'utf8') > args.limits.maxEditableBytes) {
+    throw new TextEditorOperationError(
+      'file_too_large',
+      `Edited content exceeds the editable byte limit of ${args.limits.maxEditableBytes}.`,
+    );
+  }
+
+  await writeFile(args.resolved.absolutePath, updated, 'utf8');
+
+  return { backupPath };
+}
+
+export interface InsertArgs {
+  readonly backup: BackupContext;
+  readonly insertLine: number;
+  readonly insertText: string;
+  readonly limits: OperationLimits;
+  readonly resolved: ResolvedPath;
+}
+
+export interface InsertResult {
+  readonly backupPath: string;
+}
+
+export async function insertAtLine(args: InsertArgs): Promise<InsertResult> {
+  const original = await readUtf8File(args.resolved, args.limits);
+  const lineEnding = detectLineEnding(original);
+  const lines = splitLinesPreserveEmptyTrailing(original);
+
+  if (args.insertLine > lines.length) {
+    throw new TextEditorOperationError(
+      'insert_line_out_of_bounds',
+      `insert_line=${args.insertLine} is beyond file length ${lines.length}.`,
+    );
+  }
+
+  const insertChunkLines = splitLinesPreserveEmptyTrailing(args.insertText);
+  const before = lines.slice(0, args.insertLine);
+  const after = lines.slice(args.insertLine);
+  const merged = [...before, ...insertChunkLines, ...after];
+  const updated = joinLines(merged, lineEnding);
+
+  if (Buffer.byteLength(updated, 'utf8') > args.limits.maxEditableBytes) {
+    throw new TextEditorOperationError(
+      'file_too_large',
+      `Edited content exceeds the editable byte limit of ${args.limits.maxEditableBytes}.`,
+    );
+  }
+
+  const backupPath = await snapshotFile(args.resolved, args.backup);
+  await writeFile(args.resolved.absolutePath, updated, 'utf8');
+
+  return { backupPath };
+}

--- a/workspaces/ai-engineering/llm-chat/src/tools/text-editor/path-safety.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/text-editor/path-safety.ts
@@ -1,0 +1,208 @@
+import { realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+const BLOCKED_PATH_SEGMENTS = new Set(['.git', 'node_modules']);
+const BLOCKED_FILE_PATTERNS = [/^\.env$/, /^\.env\..+$/];
+
+export const DEFAULT_BACKUP_DIRNAME = '.llm-chat-edit-backups';
+
+export class TextEditorPathError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = 'TextEditorPathError';
+  }
+}
+
+export interface ResolvePathOptions {
+  readonly allowHiddenPaths?: boolean;
+  readonly backupRoot: string;
+  readonly mustExist?: boolean;
+  readonly requestedPath: string;
+  readonly validateExistingParent?: boolean;
+  readonly workspaceRoot: string;
+}
+
+export interface ResolvedPath {
+  readonly absolutePath: string;
+  readonly relativeFromRoot: string;
+}
+
+function ensureAbsolute(value: string): string {
+  return path.isAbsolute(value) ? value : path.resolve(value);
+}
+
+function isInsideRoot(absolutePath: string, root: string): boolean {
+  const relative = path.relative(root, absolutePath);
+
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function startsWithDot(name: string): boolean {
+  return name !== '' && name !== '.' && name !== '..' && name.startsWith('.');
+}
+
+function checkBlockedSegments(relative: string, allowHiddenPaths: boolean): void {
+  if (relative === '') {
+    return;
+  }
+
+  const segments = relative.split(path.sep);
+
+  for (const segment of segments) {
+    if (segment === '') {
+      continue;
+    }
+
+    if (BLOCKED_PATH_SEGMENTS.has(segment)) {
+      throw new TextEditorPathError('blocked_path', `Path is blocked: ${segment} is not allowed.`);
+    }
+
+    if (!allowHiddenPaths && startsWithDot(segment)) {
+      throw new TextEditorPathError(
+        'blocked_hidden_path',
+        'Hidden paths are not allowed without --allow-hidden-files.',
+      );
+    }
+
+    for (const pattern of BLOCKED_FILE_PATTERNS) {
+      if (pattern.test(segment)) {
+        throw new TextEditorPathError(
+          'blocked_secret_path',
+          'Secret env paths are blocked by default.',
+        );
+      }
+    }
+  }
+}
+
+function checkBackupRoot(absolutePath: string, backupRoot: string): void {
+  const absoluteBackupRoot = ensureAbsolute(backupRoot);
+
+  if (isInsideRoot(absolutePath, absoluteBackupRoot)) {
+    throw new TextEditorPathError(
+      'blocked_backup_path',
+      'Backup directory is not exposed to the model.',
+    );
+  }
+}
+
+async function resolveSymlinkSafe(absolutePath: string): Promise<string | undefined> {
+  try {
+    return await realpath(absolutePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+async function resolveWorkspaceRoot(workspaceRoot: string): Promise<string> {
+  return (await resolveSymlinkSafe(workspaceRoot)) ?? workspaceRoot;
+}
+
+function checkRealPath(
+  realPath: string,
+  workspaceRoot: string,
+  realWorkspaceRoot: string,
+  backupRoot: string,
+  allowHiddenPaths: boolean,
+): void {
+  if (!isInsideRoot(realPath, workspaceRoot) && !isInsideRoot(realPath, realWorkspaceRoot)) {
+    throw new TextEditorPathError(
+      'symlink_escape',
+      'Path resolves outside the allowed workspace root via a symbolic link.',
+    );
+  }
+
+  checkBlockedSegments(path.relative(realWorkspaceRoot, realPath), allowHiddenPaths);
+  checkBackupRoot(realPath, backupRoot);
+}
+
+async function resolveNearestExistingParent(
+  absolutePath: string,
+  workspaceRoot: string,
+): Promise<string | undefined> {
+  let current = path.dirname(absolutePath);
+
+  while (isInsideRoot(current, workspaceRoot)) {
+    const realCurrent = await resolveSymlinkSafe(current);
+
+    if (realCurrent !== undefined) {
+      return realCurrent;
+    }
+
+    if (current === workspaceRoot) {
+      break;
+    }
+
+    current = path.dirname(current);
+  }
+
+  return undefined;
+}
+
+export async function resolveSafePath(options: ResolvePathOptions): Promise<ResolvedPath> {
+  const workspaceRoot = ensureAbsolute(options.workspaceRoot);
+  const requested = options.requestedPath;
+  const allowHiddenPaths = options.allowHiddenPaths === true;
+
+  if (typeof requested !== 'string' || requested === '') {
+    throw new TextEditorPathError('invalid_path', 'Path must be a non-empty string.');
+  }
+
+  const absolutePath = path.isAbsolute(requested)
+    ? path.normalize(requested)
+    : path.resolve(workspaceRoot, requested);
+
+  if (!isInsideRoot(absolutePath, workspaceRoot)) {
+    throw new TextEditorPathError(
+      'outside_workspace',
+      'Path is outside the allowed workspace root.',
+    );
+  }
+
+  const relativeFromRoot = path.relative(workspaceRoot, absolutePath);
+
+  checkBlockedSegments(relativeFromRoot, allowHiddenPaths);
+  checkBackupRoot(absolutePath, options.backupRoot);
+
+  const realResolved = await resolveSymlinkSafe(absolutePath);
+  const realWorkspaceRoot = await resolveWorkspaceRoot(workspaceRoot);
+
+  if (realResolved !== undefined) {
+    checkRealPath(
+      realResolved,
+      workspaceRoot,
+      realWorkspaceRoot,
+      options.backupRoot,
+      allowHiddenPaths,
+    );
+  } else if (options.validateExistingParent === true) {
+    const realParent = await resolveNearestExistingParent(absolutePath, workspaceRoot);
+
+    if (realParent === undefined) {
+      throw new TextEditorPathError('not_found', 'Workspace root does not exist.');
+    }
+
+    checkRealPath(
+      realParent,
+      workspaceRoot,
+      realWorkspaceRoot,
+      options.backupRoot,
+      allowHiddenPaths,
+    );
+  } else if (options.mustExist === true) {
+    throw new TextEditorPathError('not_found', 'Path does not exist.');
+  }
+
+  return { absolutePath, relativeFromRoot };
+}
+
+export function defaultBackupRoot(workspaceRoot: string): string {
+  return path.resolve(workspaceRoot, DEFAULT_BACKUP_DIRNAME);
+}

--- a/workspaces/ai-engineering/llm-chat/src/tools/text-editor/runtime.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/text-editor/runtime.ts
@@ -1,0 +1,228 @@
+import type { LlmToolResultBlock, LlmToolUseBlock } from '@workspaces/packages/llm-client';
+import path from 'node:path';
+
+import { parseTextEditorInput, TextEditorInputError } from './input.js';
+import {
+  createFile,
+  insertAtLine,
+  resolveLimits,
+  strReplace,
+  TextEditorOperationError,
+  viewPath,
+} from './operations.js';
+import { defaultBackupRoot, resolveSafePath, TextEditorPathError } from './path-safety.js';
+import {
+  createTextEditorToolDefinition,
+  TEXT_EDITOR_TOOL_NAME,
+  type TextEditorRuntime,
+  type TextEditorRuntimeConfig,
+  type TextEditorToolInput,
+} from './types.js';
+
+const MAX_ERROR_MESSAGE_LENGTH = 200;
+
+function sanitizeErrorMessage(message: string): string {
+  const firstLine = message.split('\n')[0] ?? 'Tool execution failed.';
+
+  return firstLine.slice(0, MAX_ERROR_MESSAGE_LENGTH);
+}
+
+interface ErrorPayload {
+  readonly code: string;
+  readonly error: string;
+}
+
+function serializeError(error: unknown, workspaceRoot?: string): string {
+  if (error instanceof TextEditorInputError) {
+    return JSON.stringify({
+      code: error.code,
+      error: sanitizeErrorMessage(error.message),
+    } satisfies ErrorPayload);
+  }
+
+  if (error instanceof TextEditorPathError) {
+    const base = sanitizeErrorMessage(error.message);
+    const hint =
+      error.code === 'outside_workspace' && workspaceRoot !== undefined
+        ? ` Workspace root: "${workspaceRoot}". Supply a path relative to this directory (e.g. "src/main.ts").`
+        : '';
+
+    return JSON.stringify({
+      code: error.code,
+      error: `${base}${hint}`,
+    } satisfies ErrorPayload);
+  }
+
+  if (error instanceof TextEditorOperationError) {
+    return JSON.stringify({
+      code: error.code,
+      error: sanitizeErrorMessage(error.message),
+    } satisfies ErrorPayload);
+  }
+
+  const message = error instanceof Error ? error.message : 'Tool execution failed.';
+
+  return JSON.stringify({
+    code: 'tool_error',
+    error: sanitizeErrorMessage(message),
+  } satisfies ErrorPayload);
+}
+
+function buildErrorResult(
+  toolUseId: string,
+  error: unknown,
+  workspaceRoot?: string,
+): LlmToolResultBlock {
+  return {
+    content: serializeError(error, workspaceRoot),
+    is_error: true,
+    tool_use_id: toolUseId,
+    type: 'tool_result',
+  };
+}
+
+interface SuccessPayload {
+  readonly backup_path?: string;
+  readonly content?: string;
+  readonly message: string;
+  readonly path: string;
+  readonly truncated?: boolean;
+}
+
+function buildSuccessResult(toolUseId: string, payload: SuccessPayload): LlmToolResultBlock {
+  return {
+    content: JSON.stringify(payload),
+    tool_use_id: toolUseId,
+    type: 'tool_result',
+  };
+}
+
+function relativeBackupPath(workspaceRoot: string, backupAbsolutePath: string): string {
+  return path.relative(workspaceRoot, backupAbsolutePath) || backupAbsolutePath;
+}
+
+export function createTextEditorRuntime(config: TextEditorRuntimeConfig): TextEditorRuntime {
+  const workspaceRoot = path.resolve(config.workspaceRoot);
+  const backupRoot = config.backupRoot ?? defaultBackupRoot(workspaceRoot);
+  const limits = resolveLimits({
+    ...(config.maxEditableBytes === undefined ? {} : { maxEditableBytes: config.maxEditableBytes }),
+    ...(config.maxViewBytes === undefined ? {} : { maxViewBytes: config.maxViewBytes }),
+    ...(config.maxViewCharacters === undefined
+      ? {}
+      : { maxViewCharacters: config.maxViewCharacters }),
+  });
+  const definition =
+    config.toolDefinition ?? createTextEditorToolDefinition(config.maxViewCharacters);
+
+  async function executeCommand(parsed: TextEditorToolInput): Promise<SuccessPayload> {
+    if (parsed.command === 'view') {
+      const resolved = await resolveSafePath({
+        ...(config.allowHiddenPaths === undefined
+          ? {}
+          : { allowHiddenPaths: config.allowHiddenPaths }),
+        backupRoot,
+        mustExist: true,
+        requestedPath: parsed.path,
+        workspaceRoot,
+      });
+      const result = await viewPath({
+        limits,
+        resolved,
+        ...(parsed.view_range === undefined ? {} : { viewRange: parsed.view_range }),
+      });
+
+      return {
+        content: result.content,
+        message: `Read ${resolved.relativeFromRoot}`,
+        path: resolved.relativeFromRoot,
+        ...(result.truncated ? { truncated: true } : {}),
+      };
+    }
+
+    if (parsed.command === 'create') {
+      const resolved = await resolveSafePath({
+        ...(config.allowHiddenPaths === undefined
+          ? {}
+          : { allowHiddenPaths: config.allowHiddenPaths }),
+        backupRoot,
+        mustExist: false,
+        requestedPath: parsed.path,
+        validateExistingParent: true,
+        workspaceRoot,
+      });
+      await createFile(resolved, parsed.file_text, limits);
+
+      return {
+        message: `Created ${resolved.relativeFromRoot}`,
+        path: resolved.relativeFromRoot,
+      };
+    }
+
+    if (parsed.command === 'str_replace') {
+      const resolved = await resolveSafePath({
+        ...(config.allowHiddenPaths === undefined
+          ? {}
+          : { allowHiddenPaths: config.allowHiddenPaths }),
+        backupRoot,
+        mustExist: true,
+        requestedPath: parsed.path,
+        workspaceRoot,
+      });
+      const result = await strReplace({
+        backup: { backupRoot, relativeFromRoot: resolved.relativeFromRoot },
+        limits,
+        newStr: parsed.new_str,
+        oldStr: parsed.old_str,
+        resolved,
+      });
+
+      return {
+        backup_path: relativeBackupPath(workspaceRoot, result.backupPath),
+        message: `Replaced text in ${resolved.relativeFromRoot}`,
+        path: resolved.relativeFromRoot,
+      };
+    }
+
+    const resolved = await resolveSafePath({
+      ...(config.allowHiddenPaths === undefined
+        ? {}
+        : { allowHiddenPaths: config.allowHiddenPaths }),
+      backupRoot,
+      mustExist: true,
+      requestedPath: parsed.path,
+      workspaceRoot,
+    });
+    const result = await insertAtLine({
+      backup: { backupRoot, relativeFromRoot: resolved.relativeFromRoot },
+      insertLine: parsed.insert_line,
+      insertText: parsed.insert_text,
+      limits,
+      resolved,
+    });
+
+    return {
+      backup_path: relativeBackupPath(workspaceRoot, result.backupPath),
+      message: `Inserted text into ${resolved.relativeFromRoot}`,
+      path: resolved.relativeFromRoot,
+    };
+  }
+
+  return {
+    definition,
+    async execute(toolUse: LlmToolUseBlock): Promise<LlmToolResultBlock> {
+      if (toolUse.inputError !== undefined) {
+        return buildErrorResult(toolUse.id, new TextEditorInputError(toolUse.inputError.message));
+      }
+
+      try {
+        const parsed = parseTextEditorInput(toolUse.input);
+        const payload = await executeCommand(parsed);
+
+        return buildSuccessResult(toolUse.id, payload);
+      } catch (error) {
+        return buildErrorResult(toolUse.id, error, workspaceRoot);
+      }
+    },
+    toolName: TEXT_EDITOR_TOOL_NAME,
+  };
+}

--- a/workspaces/ai-engineering/llm-chat/src/tools/text-editor/types.ts
+++ b/workspaces/ai-engineering/llm-chat/src/tools/text-editor/types.ts
@@ -1,0 +1,62 @@
+import type {
+  LlmAnthropicTextEditorToolDefinition,
+  LlmToolResultBlock,
+  LlmToolUseBlock,
+} from '@workspaces/packages/llm-client';
+
+export const TEXT_EDITOR_TOOL_NAME = 'str_replace_based_edit_tool' as const;
+export const TEXT_EDITOR_TOOL_TYPE = 'text_editor_20250728' as const;
+
+export type TextEditorCommand = 'view' | 'create' | 'str_replace' | 'insert';
+
+export type TextEditorToolInput =
+  | {
+      readonly command: 'view';
+      readonly path: string;
+      readonly view_range?: readonly [number, number];
+    }
+  | {
+      readonly command: 'create';
+      readonly file_text: string;
+      readonly path: string;
+    }
+  | {
+      readonly command: 'str_replace';
+      readonly new_str: string;
+      readonly old_str: string;
+      readonly path: string;
+    }
+  | {
+      readonly command: 'insert';
+      readonly insert_line: number;
+      readonly insert_text: string;
+      readonly path: string;
+    };
+
+export interface TextEditorRuntimeConfig {
+  readonly allowHiddenPaths?: boolean;
+  readonly backupRoot?: string;
+  readonly maxEditableBytes?: number;
+  readonly maxViewBytes?: number;
+  readonly maxViewCharacters?: number;
+  readonly toolDefinition?: LlmAnthropicTextEditorToolDefinition;
+  readonly workspaceRoot: string;
+}
+
+export interface TextEditorRuntime {
+  readonly definition: LlmAnthropicTextEditorToolDefinition;
+  readonly toolName: typeof TEXT_EDITOR_TOOL_NAME;
+  execute(toolUse: LlmToolUseBlock): Promise<LlmToolResultBlock>;
+}
+
+export function createTextEditorToolDefinition(
+  maxCharacters?: number,
+): LlmAnthropicTextEditorToolDefinition {
+  return {
+    kind: 'anthropic_builtin',
+    name: TEXT_EDITOR_TOOL_NAME,
+    provider: 'anthropic',
+    type: TEXT_EDITOR_TOOL_TYPE,
+    ...(maxCharacters === undefined ? {} : { maxCharacters }),
+  };
+}

--- a/workspaces/ai-engineering/llm-chat/tests/chat/service.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/chat/service.test.ts
@@ -460,6 +460,107 @@ describe('chat service', () => {
     }
   });
 
+  it('sends both custom and built-in client tool definitions in the request', async () => {
+    const messages: Messages = [];
+    const customTool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'my_tool' },
+      execute: () => ({}),
+    };
+    const { calls, provider } = createSequenceProvider([
+      { content: [{ text: 'done', type: 'text' }], raw: {}, stopReason: 'end_turn', text: 'done' },
+    ]);
+
+    const builtinDefinition = {
+      kind: 'anthropic_builtin' as const,
+      name: 'str_replace_based_edit_tool' as const,
+      provider: 'anthropic' as const,
+      type: 'text_editor_20250728' as const,
+    };
+
+    const service = createChatService({
+      builtinClientTools: [
+        {
+          definition: builtinDefinition,
+          runtime: {
+            execute: () =>
+              Promise.resolve({
+                content: '{}',
+                tool_use_id: 'X',
+                type: 'tool_result' as const,
+              }),
+            toolName: 'str_replace_based_edit_tool',
+          },
+        },
+      ],
+      model: DEFAULT_MODEL,
+      provider,
+      tools: [customTool],
+    });
+    await service.sendUserTurn(messages, 'hi', { toolsEnabled: true });
+
+    expect(calls[0]?.tools).toEqual([customTool.definition, builtinDefinition]);
+  });
+
+  it('routes a builtin tool_use call to the registered client runtime', async () => {
+    const messages: Messages = [];
+    const customTool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'my_tool' },
+      execute: vi.fn(),
+    };
+    const builtinExecute = vi.fn().mockResolvedValue({
+      content: '{"message":"viewed"}',
+      tool_use_id: 'use_E',
+      type: 'tool_result' as const,
+    });
+    const { provider } = createSequenceProvider([
+      {
+        content: [
+          {
+            id: 'use_E',
+            input: { command: 'view', path: 'a.txt' },
+            name: 'str_replace_based_edit_tool',
+            type: 'tool_use',
+          },
+        ],
+        raw: {},
+        stopReason: 'tool_use',
+        text: '',
+      },
+      { content: [{ text: 'ok', type: 'text' }], raw: {}, stopReason: 'end_turn', text: 'ok' },
+    ]);
+
+    const service = createChatService({
+      builtinClientTools: [
+        {
+          definition: {
+            kind: 'anthropic_builtin' as const,
+            name: 'str_replace_based_edit_tool' as const,
+            provider: 'anthropic' as const,
+            type: 'text_editor_20250728' as const,
+          },
+          runtime: { execute: builtinExecute, toolName: 'str_replace_based_edit_tool' },
+        },
+      ],
+      model: DEFAULT_MODEL,
+      provider,
+      tools: [customTool],
+    });
+    await service.sendUserTurn(messages, 'view file', { toolsEnabled: true });
+
+    expect(customTool.execute).not.toHaveBeenCalled();
+    expect(builtinExecute).toHaveBeenCalledOnce();
+    expect(messages[2]).toEqual({
+      content: [
+        {
+          content: '{"message":"viewed"}',
+          tool_use_id: 'use_E',
+          type: 'tool_result',
+        },
+      ],
+      role: 'user',
+    });
+  });
+
   it('enforces the max tool round guard', async () => {
     const messages: Messages = [];
     const tool: AppTool = {

--- a/workspaces/ai-engineering/llm-chat/tests/cli/args.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/cli/args.test.ts
@@ -99,6 +99,67 @@ describe('parseArgs', () => {
   it('rejects unknown arguments', () => {
     expect(() => parseArgs(['--nope'])).toThrow(/Unknown argument/);
   });
+
+  it('parses --edit-files with --tools', () => {
+    expect(parseArgs(['--tools', '--edit-files'])).toEqual({
+      options: { editFiles: {}, toolsEnabled: true },
+      shouldPrintHelp: false,
+    });
+  });
+
+  it('rejects --edit-files without --tools', () => {
+    expect(() => parseArgs(['--edit-files'])).toThrow(/--edit-files requires --tools/);
+  });
+
+  it('rejects --edit-files with --fine-grained-tool-streaming', () => {
+    expect(() => parseArgs(['--tools', '--edit-files', '--fine-grained-tool-streaming'])).toThrow(
+      /cannot be combined with --fine-grained-tool-streaming/,
+    );
+  });
+
+  it('parses --workspace-root with --edit-files', () => {
+    expect(parseArgs(['--tools', '--edit-files', '--workspace-root=/tmp/safe'])).toEqual({
+      options: { editFiles: { workspaceRoot: '/tmp/safe' }, toolsEnabled: true },
+      shouldPrintHelp: false,
+    });
+  });
+
+  it('rejects empty --workspace-root', () => {
+    expect(() => parseArgs(['--tools', '--edit-files', '--workspace-root='])).toThrow(
+      /--workspace-root must be a non-empty path/,
+    );
+  });
+
+  it('rejects --workspace-root without --edit-files', () => {
+    expect(() => parseArgs(['--tools', '--workspace-root=/tmp/safe'])).toThrow(
+      /--workspace-root requires --edit-files/,
+    );
+  });
+
+  it('parses --text-editor-max-characters with --edit-files', () => {
+    expect(parseArgs(['--tools', '--edit-files', '--text-editor-max-characters=10000'])).toEqual({
+      options: {
+        editFiles: { textEditorMaxCharacters: 10_000 },
+        toolsEnabled: true,
+      },
+      shouldPrintHelp: false,
+    });
+  });
+
+  it('rejects non-positive --text-editor-max-characters', () => {
+    expect(() => parseArgs(['--tools', '--edit-files', '--text-editor-max-characters=0'])).toThrow(
+      /positive integer/,
+    );
+    expect(() =>
+      parseArgs(['--tools', '--edit-files', '--text-editor-max-characters=abc']),
+    ).toThrow(/positive integer/);
+  });
+
+  it('rejects --text-editor-max-characters without --edit-files', () => {
+    expect(() => parseArgs(['--tools', '--text-editor-max-characters=10000'])).toThrow(
+      /--text-editor-max-characters requires --edit-files/,
+    );
+  });
 });
 
 describe('helpText', () => {
@@ -111,5 +172,8 @@ describe('helpText', () => {
     expect(text).toContain('--structured-commands');
     expect(text).toContain('--tools');
     expect(text).toContain('--fine-grained-tool-streaming');
+    expect(text).toContain('--edit-files');
+    expect(text).toContain('--workspace-root');
+    expect(text).toContain('--text-editor-max-characters');
   });
 });

--- a/workspaces/ai-engineering/llm-chat/tests/tools/runner.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/tools/runner.test.ts
@@ -111,6 +111,38 @@ describe('tool runner', () => {
     expect(result.tool_use_id).toBe('use_X');
   });
 
+  it('returns a sanitized error result when a client runtime fails', async () => {
+    const customTool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'my_tool' },
+      execute: vi.fn(),
+    };
+    const clientRuntime = {
+      execute: vi.fn().mockRejectedValue(new Error('runtime failed\n    at internal stack frame')),
+      toolName: 'str_replace_based_edit_tool',
+    };
+
+    const result = await executeToolUse(
+      {
+        id: 'use_runtime_error',
+        input: { command: 'view', path: 'x' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      },
+      [customTool],
+      context,
+      [clientRuntime],
+    );
+
+    expect(clientRuntime.execute).toHaveBeenCalledOnce();
+    expect(customTool.execute).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: '{"error":"runtime failed"}',
+      is_error: true,
+      tool_use_id: 'use_runtime_error',
+      type: 'tool_result',
+    });
+  });
+
   it('does not let client runtimes intercept normal custom tool calls', async () => {
     const customTool: AppTool = {
       definition: { inputSchema: { type: 'object' }, name: 'my_tool' },

--- a/workspaces/ai-engineering/llm-chat/tests/tools/runner.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/tools/runner.test.ts
@@ -80,6 +80,63 @@ describe('tool runner', () => {
     });
   });
 
+  it('routes a tool_use call to a matching client runtime when one is registered', async () => {
+    const customTool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'my_tool' },
+      execute: vi.fn().mockReturnValue({ ok: true }),
+    };
+    const clientRuntime = {
+      execute: vi.fn().mockResolvedValue({
+        content: '{"path":"x"}',
+        tool_use_id: 'use_X',
+        type: 'tool_result' as const,
+      }),
+      toolName: 'str_replace_based_edit_tool',
+    };
+
+    const result = await executeToolUse(
+      {
+        id: 'use_X',
+        input: { command: 'view', path: 'x' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      },
+      [customTool],
+      context,
+      [clientRuntime],
+    );
+
+    expect(clientRuntime.execute).toHaveBeenCalledTimes(1);
+    expect(customTool.execute).not.toHaveBeenCalled();
+    expect(result.tool_use_id).toBe('use_X');
+  });
+
+  it('does not let client runtimes intercept normal custom tool calls', async () => {
+    const customTool: AppTool = {
+      definition: { inputSchema: { type: 'object' }, name: 'my_tool' },
+      execute: vi.fn().mockReturnValue({ ok: true }),
+    };
+    const clientRuntime = {
+      execute: vi.fn(),
+      toolName: 'str_replace_based_edit_tool',
+    };
+
+    const result = await executeToolUse(
+      { id: 'use_Y', input: {}, name: 'my_tool', type: 'tool_use' },
+      [customTool],
+      context,
+      [clientRuntime],
+    );
+
+    expect(clientRuntime.execute).not.toHaveBeenCalled();
+    expect(customTool.execute).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      content: '{"ok":true}',
+      tool_use_id: 'use_Y',
+      type: 'tool_result',
+    });
+  });
+
   it('returns a sanitized error result for thrown validation errors', async () => {
     const tool: AppTool = {
       definition: {

--- a/workspaces/ai-engineering/llm-chat/tests/tools/text-editor/runtime.test.ts
+++ b/workspaces/ai-engineering/llm-chat/tests/tools/text-editor/runtime.test.ts
@@ -1,0 +1,425 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createTextEditorRuntime } from '../../../src/tools/text-editor/runtime.js';
+
+interface ResultPayload {
+  readonly backup_path?: string;
+  readonly content?: string;
+  readonly error?: string;
+  readonly code?: string;
+  readonly message?: string;
+  readonly path?: string;
+  readonly truncated?: boolean;
+}
+
+function parseResult(content: string): ResultPayload {
+  return JSON.parse(content) as ResultPayload;
+}
+
+describe('text editor runtime', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), 'text-editor-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { force: true, recursive: true });
+  });
+
+  describe('view', () => {
+    it('reads an allowed file with line-numbered output', async () => {
+      const filePath = path.join(workspaceRoot, 'note.txt');
+      await writeFile(filePath, 'first\nsecond\nthird\n', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_1',
+        input: { command: 'view', path: 'note.txt' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBeUndefined();
+      const payload = parseResult(result.content);
+      expect(payload.path).toBe('note.txt');
+      expect(payload.content).toContain('1\tfirst');
+      expect(payload.content).toContain('2\tsecond');
+      expect(payload.content).toContain('3\tthird');
+    });
+
+    it('supports view_range', async () => {
+      const filePath = path.join(workspaceRoot, 'lines.txt');
+      await writeFile(filePath, 'a\nb\nc\nd\ne\n', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_2',
+        input: { command: 'view', path: 'lines.txt', view_range: [2, 4] },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      const payload = parseResult(result.content);
+      expect(payload.content).toContain('2\tb');
+      expect(payload.content).toContain('3\tc');
+      expect(payload.content).toContain('4\td');
+      expect(payload.content).not.toContain('1\ta');
+      expect(payload.content).not.toContain('5\te');
+    });
+
+    it('rejects a path outside workspace root', async () => {
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_3',
+        input: { command: 'view', path: '/etc/passwd' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('outside_workspace');
+    });
+
+    it('rejects parent traversal', async () => {
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_4',
+        input: { command: 'view', path: '../escaped.txt' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('outside_workspace');
+    });
+
+    it('rejects binary files', async () => {
+      const filePath = path.join(workspaceRoot, 'binary.bin');
+      await writeFile(filePath, Buffer.from([0x00, 0x01, 0x02, 0x03]));
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_5',
+        input: { command: 'view', path: 'binary.bin' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('binary_file');
+    });
+
+    it('truncates large output when maxViewCharacters is set', async () => {
+      const filePath = path.join(workspaceRoot, 'big.txt');
+      await writeFile(filePath, 'a'.repeat(500), 'utf8');
+
+      const runtime = createTextEditorRuntime({ maxViewCharacters: 50, workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_6',
+        input: { command: 'view', path: 'big.txt' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      const payload = parseResult(result.content);
+      expect(payload.truncated).toBe(true);
+    });
+
+    it('rejects symlink escapes', async () => {
+      const linkPath = path.join(workspaceRoot, 'escape-link');
+      await symlink('/etc/hosts', linkPath);
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_7',
+        input: { command: 'view', path: 'escape-link' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('symlink_escape');
+    });
+
+    it('lists allowed directory contents without recursion', async () => {
+      await writeFile(path.join(workspaceRoot, 'a.txt'), 'a', 'utf8');
+      await mkdir(path.join(workspaceRoot, 'sub'));
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_dir',
+        input: { command: 'view', path: '.' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      const payload = parseResult(result.content);
+      expect(payload.content).toContain('- a.txt');
+      expect(payload.content).toContain('d sub');
+    });
+  });
+
+  describe('create', () => {
+    it('creates a file under the allowed root', async () => {
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_c1',
+        input: { command: 'create', file_text: 'hello\n', path: 'new/file.txt' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBeUndefined();
+      const onDisk = await readFile(path.join(workspaceRoot, 'new/file.txt'), 'utf8');
+      expect(onDisk).toBe('hello\n');
+    });
+
+    it('refuses to overwrite an existing file', async () => {
+      await writeFile(path.join(workspaceRoot, 'existing.txt'), 'old', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_c2',
+        input: { command: 'create', file_text: 'new', path: 'existing.txt' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('file_exists');
+    });
+
+    it('rejects creating hidden files by default', async () => {
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_c3',
+        input: { command: 'create', file_text: 'X', path: '.secret' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('blocked_hidden_path');
+    });
+
+    it('rejects creating .env files even when allowHiddenPaths is true', async () => {
+      const runtime = createTextEditorRuntime({ allowHiddenPaths: true, workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_c4',
+        input: { command: 'create', file_text: 'KEY=secret', path: '.env' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('blocked_secret_path');
+    });
+
+    it('rejects creating files through a symlinked parent outside the workspace', async () => {
+      const outsideRoot = await mkdtemp(path.join(tmpdir(), 'text-editor-outside-'));
+
+      try {
+        await symlink(outsideRoot, path.join(workspaceRoot, 'outside-link'));
+
+        const runtime = createTextEditorRuntime({ workspaceRoot });
+        const result = await runtime.execute({
+          id: 'use_c5',
+          input: {
+            command: 'create',
+            file_text: 'escaped',
+            path: 'outside-link/nested/escaped.txt',
+          },
+          name: 'str_replace_based_edit_tool',
+          type: 'tool_use',
+        });
+
+        expect(result.is_error).toBe(true);
+        expect(parseResult(result.content).code).toBe('symlink_escape');
+        await expect(
+          readFile(path.join(outsideRoot, 'nested/escaped.txt'), 'utf8'),
+        ).rejects.toMatchObject({
+          code: 'ENOENT',
+        });
+      } finally {
+        await rm(outsideRoot, { force: true, recursive: true });
+      }
+    });
+  });
+
+  describe('str_replace', () => {
+    it('replaces a single match and creates a backup', async () => {
+      const filePath = path.join(workspaceRoot, 'target.txt');
+      await writeFile(filePath, 'one\ntwo\nthree\n', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_s1',
+        input: {
+          command: 'str_replace',
+          new_str: 'TWO',
+          old_str: 'two',
+          path: 'target.txt',
+        },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBeUndefined();
+      const updated = await readFile(filePath, 'utf8');
+      expect(updated).toBe('one\nTWO\nthree\n');
+      const payload = parseResult(result.content);
+      expect(payload.backup_path).toBeDefined();
+
+      const backupContents = await readFile(
+        path.join(workspaceRoot, payload.backup_path ?? ''),
+        'utf8',
+      );
+      expect(backupContents).toBe('one\ntwo\nthree\n');
+    });
+
+    it('fails when old_str has zero matches', async () => {
+      const filePath = path.join(workspaceRoot, 'target.txt');
+      await writeFile(filePath, 'abc', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_s2',
+        input: {
+          command: 'str_replace',
+          new_str: 'NEW',
+          old_str: 'xyz',
+          path: 'target.txt',
+        },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('no_match');
+    });
+
+    it('fails when old_str has multiple matches', async () => {
+      const filePath = path.join(workspaceRoot, 'target.txt');
+      await writeFile(filePath, 'foo bar foo', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_s3',
+        input: {
+          command: 'str_replace',
+          new_str: 'baz',
+          old_str: 'foo',
+          path: 'target.txt',
+        },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('multiple_matches');
+    });
+  });
+
+  describe('insert', () => {
+    it('inserts after the given line and creates a backup', async () => {
+      const filePath = path.join(workspaceRoot, 'list.txt');
+      await writeFile(filePath, 'a\nb\nc\n', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_i1',
+        input: {
+          command: 'insert',
+          insert_line: 2,
+          insert_text: 'middle',
+          path: 'list.txt',
+        },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBeUndefined();
+      const updated = await readFile(filePath, 'utf8');
+      expect(updated).toBe('a\nb\nmiddle\nc\n');
+      expect(parseResult(result.content).backup_path).toBeDefined();
+    });
+
+    it('supports insert_line=0 for beginning of file', async () => {
+      const filePath = path.join(workspaceRoot, 'list.txt');
+      await writeFile(filePath, 'a\nb\n', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      await runtime.execute({
+        id: 'use_i2',
+        input: { command: 'insert', insert_line: 0, insert_text: 'top', path: 'list.txt' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      const updated = await readFile(filePath, 'utf8');
+      expect(updated).toBe('top\na\nb\n');
+    });
+
+    it('rejects insert_line beyond file length', async () => {
+      const filePath = path.join(workspaceRoot, 'list.txt');
+      await writeFile(filePath, 'a\nb\n', 'utf8');
+
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_i3',
+        input: { command: 'insert', insert_line: 10, insert_text: 'x', path: 'list.txt' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('insert_line_out_of_bounds');
+    });
+  });
+
+  describe('error handling', () => {
+    it('rejects undo_edit', async () => {
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_u1',
+        input: { command: 'undo_edit', path: 'whatever' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('invalid_input');
+    });
+
+    it('rejects unknown commands', async () => {
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_u2',
+        input: { command: 'rename', path: 'a' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('invalid_input');
+    });
+
+    it('returns an error when inputError is set on the tool_use block', async () => {
+      const runtime = createTextEditorRuntime({ workspaceRoot });
+      const result = await runtime.execute({
+        id: 'use_u3',
+        input: {},
+        inputError: { code: 'invalid_json', message: 'Invalid tool input JSON.' },
+        name: 'str_replace_based_edit_tool',
+        type: 'tool_use',
+      });
+
+      expect(result.is_error).toBe(true);
+      expect(parseResult(result.content).code).toBe('invalid_input');
+    });
+  });
+});

--- a/workspaces/packages/llm-client/src/anthropic/messages-api.ts
+++ b/workspaces/packages/llm-client/src/anthropic/messages-api.ts
@@ -5,10 +5,13 @@ import type {
   Message,
   MessageParam,
   Tool,
+  ToolTextEditor20250728,
+  ToolUnion,
 } from '@anthropic-ai/sdk/resources/messages/messages';
 
 import type {
   LlmContentBlock,
+  LlmCustomToolDefinition,
   LlmProvider,
   LlmRequest,
   LlmResponse,
@@ -19,6 +22,12 @@ import type {
 import { textFromMessage } from './text.js';
 import { accumulateToolInputStream } from './tool-input-stream.js';
 
+function isAnthropicBuiltinToolDefinition(
+  tool: LlmToolDefinition,
+): tool is Extract<LlmToolDefinition, { readonly kind: 'anthropic_builtin' }> {
+  return tool.kind === 'anthropic_builtin';
+}
+
 function toAnthropicInputSchema(schema: LlmToolInputSchema): Tool.InputSchema {
   const { required, ...rest } = schema;
 
@@ -28,17 +37,37 @@ function toAnthropicInputSchema(schema: LlmToolInputSchema): Tool.InputSchema {
   } as Tool.InputSchema;
 }
 
-export function toAnthropicTools(
-  tools: readonly LlmToolDefinition[],
-  eagerInputStreaming = false,
-): Tool[] {
-  return tools.map((tool) => ({
+function toAnthropicCustomTool(tool: LlmCustomToolDefinition, eagerInputStreaming: boolean): Tool {
+  return {
     input_schema: toAnthropicInputSchema(tool.inputSchema),
     name: tool.name,
     ...(tool.description === undefined ? {} : { description: tool.description }),
     ...(tool.inputExamples === undefined ? {} : { input_examples: [...tool.inputExamples] }),
     ...(eagerInputStreaming ? { eager_input_streaming: true as const } : {}),
-  }));
+  };
+}
+
+function toAnthropicTextEditorTool(
+  tool: Extract<LlmToolDefinition, { readonly kind: 'anthropic_builtin' }>,
+): ToolTextEditor20250728 {
+  return {
+    name: tool.name,
+    type: tool.type,
+    ...(tool.maxCharacters === undefined ? {} : { max_characters: tool.maxCharacters }),
+  };
+}
+
+export function toAnthropicTools(
+  tools: readonly LlmToolDefinition[],
+  eagerInputStreaming = false,
+): ToolUnion[] {
+  return tools.map((tool) => {
+    if (isAnthropicBuiltinToolDefinition(tool)) {
+      return toAnthropicTextEditorTool(tool);
+    }
+
+    return toAnthropicCustomTool(tool, eagerInputStreaming);
+  });
 }
 
 function toAnthropicContentBlock(block: LlmContentBlock): ContentBlockParam {

--- a/workspaces/packages/llm-client/src/index.ts
+++ b/workspaces/packages/llm-client/src/index.ts
@@ -6,7 +6,9 @@ export type { AppConfig } from './config/env.js';
 export { createProvider } from './provider-factory.js';
 export type {
   ChatMessage,
+  LlmAnthropicTextEditorToolDefinition,
   LlmContentBlock,
+  LlmCustomToolDefinition,
   LlmProvider,
   LlmRequest,
   LlmResponse,

--- a/workspaces/packages/llm-client/src/types.ts
+++ b/workspaces/packages/llm-client/src/types.ts
@@ -40,12 +40,23 @@ export interface LlmToolInputSchema {
   readonly [key: string]: unknown;
 }
 
-export interface LlmToolDefinition {
+export interface LlmCustomToolDefinition {
+  readonly kind?: 'custom';
   readonly description?: string;
   readonly inputExamples?: readonly Record<string, unknown>[];
   readonly inputSchema: LlmToolInputSchema;
   readonly name: string;
 }
+
+export interface LlmAnthropicTextEditorToolDefinition {
+  readonly kind: 'anthropic_builtin';
+  readonly maxCharacters?: number;
+  readonly name: 'str_replace_based_edit_tool';
+  readonly provider: 'anthropic';
+  readonly type: 'text_editor_20250728';
+}
+
+export type LlmToolDefinition = LlmCustomToolDefinition | LlmAnthropicTextEditorToolDefinition;
 
 export interface ChatMessage {
   content: string | readonly LlmContentBlock[];

--- a/workspaces/packages/llm-client/tests/anthropic/messages-api.test.ts
+++ b/workspaces/packages/llm-client/tests/anthropic/messages-api.test.ts
@@ -441,6 +441,152 @@ describe('createAnthropicProvider', () => {
     });
   });
 
+  it('maps an Anthropic Text Editor tool definition without input_schema and forwards max_characters', async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ text: 'ok', type: 'text' }],
+      stop_reason: 'end_turn',
+    });
+    const client = { messages: { create } } as unknown as Anthropic;
+
+    const provider = createAnthropicProvider(client);
+    await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'view file', role: 'user' }],
+      model: DEFAULT_MODEL,
+      stream: false,
+      tools: [
+        {
+          kind: 'anthropic_builtin',
+          maxCharacters: 8000,
+          name: 'str_replace_based_edit_tool',
+          provider: 'anthropic',
+          type: 'text_editor_20250728',
+        },
+      ],
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [
+          {
+            max_characters: 8000,
+            name: 'str_replace_based_edit_tool',
+            type: 'text_editor_20250728',
+          },
+        ],
+      }),
+    );
+    const toolsArg = create.mock.calls[0]?.[0]?.tools as readonly Record<string, unknown>[];
+    expect(toolsArg[0]).not.toHaveProperty('input_schema');
+    expect(toolsArg[0]).not.toHaveProperty('eager_input_streaming');
+  });
+
+  it('omits max_characters when not provided on the text editor tool', async () => {
+    const create = vi.fn().mockResolvedValue({
+      content: [{ text: 'ok', type: 'text' }],
+      stop_reason: 'end_turn',
+    });
+    const client = { messages: { create } } as unknown as Anthropic;
+
+    const provider = createAnthropicProvider(client);
+    await provider.createMessage({
+      maxTokens: 100,
+      messages: [{ content: 'view file', role: 'user' }],
+      model: DEFAULT_MODEL,
+      stream: false,
+      tools: [
+        {
+          kind: 'anthropic_builtin',
+          name: 'str_replace_based_edit_tool',
+          provider: 'anthropic',
+          type: 'text_editor_20250728',
+        },
+      ],
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [
+          {
+            name: 'str_replace_based_edit_tool',
+            type: 'text_editor_20250728',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('does not add eager_input_streaming to the text editor tool when fine-grained streaming is enabled', async () => {
+    const events: Anthropic.Messages.MessageStreamEvent[] = [
+      {
+        delta: {
+          container: null,
+          stop_details: null,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+        },
+        type: 'message_delta',
+        usage: { output_tokens: 1 },
+      },
+      { type: 'message_stop' },
+    ] as unknown as Anthropic.Messages.MessageStreamEvent[];
+    const finalMessage = vi.fn().mockResolvedValue({
+      content: [{ text: 'ok', type: 'text' }],
+      stop_reason: 'end_turn',
+    });
+    let capturedParams: unknown;
+    const stream = vi.fn().mockImplementation((params) => {
+      capturedParams = params;
+
+      return {
+        finalMessage,
+        [Symbol.asyncIterator]() {
+          let i = 0;
+
+          return {
+            next() {
+              const event = events[i++];
+
+              return Promise.resolve(
+                event === undefined
+                  ? { done: true as const, value: undefined }
+                  : { done: false, value: event },
+              );
+            },
+          };
+        },
+      };
+    });
+    const client = { messages: { stream } } as unknown as Anthropic;
+
+    const provider = createAnthropicProvider(client);
+    await provider.createMessage({
+      fineGrainedToolStreaming: true,
+      maxTokens: 100,
+      messages: [{ content: 'view file', role: 'user' }],
+      model: DEFAULT_MODEL,
+      tools: [
+        {
+          kind: 'anthropic_builtin',
+          name: 'str_replace_based_edit_tool',
+          provider: 'anthropic',
+          type: 'text_editor_20250728',
+        },
+      ],
+    });
+
+    expect(capturedParams).toMatchObject({
+      tools: [
+        {
+          name: 'str_replace_based_edit_tool',
+          type: 'text_editor_20250728',
+        },
+      ],
+    });
+    const toolsArg = (capturedParams as { tools: readonly Record<string, unknown>[] }).tools;
+    expect(toolsArg[0]).not.toHaveProperty('eager_input_streaming');
+  });
+
   it('does not include eager_input_streaming on tools when fineGrainedToolStreaming is not enabled', async () => {
     const create = vi.fn().mockResolvedValue({
       content: [{ id: 'toolu_1', input: {}, name: 'my_tool', type: 'tool_use' }],


### PR DESCRIPTION
- Add str_replace_based_edit_tool built-in tool support: view, create, str_replace, insert commands with line-numbered output and view_range
- Enforce workspace root boundary: normalisation, blocked segments (.git, node_modules, .env*), hidden-path guard, symlink-escape check via realpath on both target and workspace root (handles macOS /var symlink)
- Write backups to .llm-chat-edit-backups/<relative-path> before every write
- New CLI flags: --edit-files, --workspace-root=<path>, --text-editor-max-characters=<n>; --edit-files requires --tools and rejects --fine-grained-tool-streaming in v1
- Include workspace root in system prompt and outside_workspace error messages so the model can construct valid paths without trial-and-error
- Widen LlmToolDefinition to discriminated union (custom | anthropic_builtin) in llm-client; update toAnthropicTools to return ToolUnion[]
- Add ClientToolRuntime routing in runner and BuiltinClientTool in ChatServiceConfig to merge built-in + custom tool definitions
- 238 tests pass (includes ~30 new runtime tests via mkdtemp temp dirs)