### PR TITLE
chore(agent): reduce AI-agent context cost and gate task-context handoff updates

### DIFF
--- a/.agents/commands/debug.md
+++ b/.agents/commands/debug.md
@@ -7,7 +7,7 @@ Use this as a runnable prompt for debugging failures in this repo.
 1. Read `AGENTS.md` and the rules under `.agents/rules/`.
 2. Read and follow [.agents/skills/debug/SKILL.md](../skills/debug/SKILL.md).
 3. Use [.agents/skills/validate/SKILL.md](../skills/validate/SKILL.md) for focused verification.
-4. Update `docs/CURRENT_TASK_CONTEXT.md` with [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) after a meaningful fix or investigation.
+4. When a handoff is useful — work continues across turns, tools, or sessions — update `docs/CURRENT_TASK_CONTEXT.md` per [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) (see its `When To Use` / `When Not To Use`).
 
 ## User Input
 

--- a/.agents/commands/implement.md
+++ b/.agents/commands/implement.md
@@ -8,7 +8,7 @@ Use this as a runnable prompt for focused implementation work in this repo.
 2. Read and follow [.agents/skills/implement/SKILL.md](../skills/implement/SKILL.md).
 3. Load any focused skills named by the implement skill that match the task.
 4. Use [.agents/skills/validate/SKILL.md](../skills/validate/SKILL.md) before finishing.
-5. Update `docs/CURRENT_TASK_CONTEXT.md` with [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) after meaningful changes.
+5. When a handoff is useful — work continues across turns, tools, or sessions — update `docs/CURRENT_TASK_CONTEXT.md` per [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) (see its `When To Use` / `When Not To Use`).
 
 ## User Input
 

--- a/.agents/commands/improve-token-usage.md
+++ b/.agents/commands/improve-token-usage.md
@@ -1,0 +1,99 @@
+# Improve Token Usage Command
+
+Use this as a runnable prompt to investigate AI-session context cost and produce
+an execution-ready plan for reducing token usage without lowering answer quality.
+
+## Run
+
+1. Read `AGENTS.md` and the rules under `.agents/rules/`.
+2. Read and follow [.agents/skills/plan/SKILL.md](../skills/plan/SKILL.md).
+3. Treat this as investigation and planning only. Do not edit source, tests,
+   hooks, config, or instruction files while producing the plan.
+4. Use the plan skill's artifact policy and file template. Prefer
+   `docs/plan-improve-token-usage.md` unless the user provides another output
+   path.
+5. If previous investigation artifacts exist, verify stale claims before reusing
+   them and produce a compact actionable plan instead of appending another long
+   audit narrative.
+6. For AI-agent guidance, check current official Codex and Claude docs plus
+   official changelogs. Use a 30-day recency window first, and broaden to
+   90 days only if the 30-day pass has no useful dated updates.
+
+## Investigation Brief
+
+Goal: improve token usage in Codex / Claude sessions without losing output
+quality.
+
+Context: this repository often reaches token or context limits during AI coding
+sessions. The plan should identify where context can be reduced while keeping
+enough repo knowledge for high-quality answers and safe code changes.
+
+Recommendation style:
+
+- Prefer practical, low-risk improvements.
+- Keep recommendations tool-agnostic where possible.
+- Add Codex- or Claude-specific advice only when the tool behavior differs.
+- Avoid removing important project-specific knowledge.
+- Preserve enough repo orientation, safety rules, and validation discipline for
+  high-quality answers and safe code changes.
+
+Investigate:
+
+1. Which files, folders, docs, rules, prompts, generated files, reports, or
+   sample assets may consume too many tokens.
+2. Which context is essential, and which context can be shortened, moved,
+   ignored, summarized, or loaded only on demand.
+3. Whether AI instruction files are too verbose, duplicated, or loaded too
+   often.
+4. How to improve the structure of agent instructions, rules, skills, commands,
+   hooks, prompts, and docs so AI tools use less context.
+5. What should be added to `.gitignore`, Claude `permissions.deny`, Codex
+   config, hooks, or tool-specific guidance to avoid unnecessary context
+   loading.
+6. How to keep quality high while reducing context size.
+
+## Evidence Rules
+
+- Prefer cheap repo evidence before opening large files:
+  - `git status --short`
+  - `git ls-files <path>`
+  - `git check-ignore -v <path>`
+  - `wc -l <files>`
+  - `wc -c <files>`
+  - `rg --files <focused-paths>`
+- Use `git ls-files` or `rg --files` with focused paths for discovery.
+- Every finding should include concrete file or folder references, and line
+  numbers when they are useful.
+- Do not bulk-read `node_modules`, `.pnpm-store`, `dist`, `build`,
+  `.playwright-mcp`, generated reports, generated outputs, binary assets, or
+  broad `docs/_todo/**` content unless the task explicitly requires them.
+- Verify drift-prone findings before turning them into priority actions.
+- Redact secrets and do not quote tokens, credentials, private URLs, or local
+  secret-bearing config values.
+
+## Plan Content Requirements
+
+Use the plan skill's plan file template, and make sure the resulting plan
+includes:
+
+- a short summary of the current token-usage problems
+- concrete findings with file/folder references
+- recommended actions ordered by priority
+- suggested improved structure for AI instruction/context files, if needed
+- things that should not change because they preserve quality
+- tool-specific notes for Codex and Claude where relevant
+- validation commands or evidence checks for each meaningful action
+- a small checklist for starting a new Codex / Claude session
+
+The plan should be execution-ready for another LLM, practical, low risk, and
+ordered so a future session can apply one focused change at a time.
+
+## Final Response
+
+Report:
+
+- plan file path
+- highest-priority actions
+- validation or evidence commands used
+- official sources checked and whether the 30-day window was enough
+- anything intentionally left unmodified

--- a/.agents/commands/update-docs.md
+++ b/.agents/commands/update-docs.md
@@ -7,7 +7,7 @@ Use this as a runnable prompt for documentation updates.
 1. Read `AGENTS.md` and the rules under `.agents/rules/`.
 2. Read and follow [.agents/skills/update-docs/SKILL.md](../skills/update-docs/SKILL.md).
 3. For AI-agent guidance, follow the `Freshness Window` and `AI-Agent Docs Review` sections in that skill before editing; report sources checked, the recency window used, and any structure recommendation.
-4. Update `docs/CURRENT_TASK_CONTEXT.md` with [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) after meaningful documentation changes.
+4. When a handoff is useful — work continues across turns, tools, or sessions — update `docs/CURRENT_TASK_CONTEXT.md` per [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) (see its `When To Use` / `When Not To Use`).
 
 ## User Input
 

--- a/.agents/commands/validate-changed.md
+++ b/.agents/commands/validate-changed.md
@@ -8,7 +8,7 @@ Use this as a runnable prompt for scoped validation of the current changed files
 2. Read and follow [.agents/skills/validate/SKILL.md](../skills/validate/SKILL.md).
 3. Run `pnpm run validate:changed`.
 4. If validation fails, summarize the failing phase and use focused follow-up checks after any fix.
-5. Update `docs/CURRENT_TASK_CONTEXT.md` with [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) after meaningful investigation or fixes.
+5. When a handoff is useful — work continues across turns, tools, or sessions — update `docs/CURRENT_TASK_CONTEXT.md` per [.agents/skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) (see its `When To Use` / `When Not To Use`).
 
 ## User Input
 

--- a/.agents/hooks/README.md
+++ b/.agents/hooks/README.md
@@ -1,130 +1,55 @@
-# Hook Runbook
+# Hook Map
 
-Portable Node.js hook scripts for Codex and Claude Code live in this folder.
-Tool adapters stay thin:
+Portable Node.js hook scripts for Codex and Claude Code live here. Keep hook
+behavior in executable scripts and keep tool adapters thin.
 
 - Codex wiring: [../../.codex/hooks.json](../../.codex/hooks.json)
 - Claude wiring: [../../.claude/settings.json](../../.claude/settings.json)
-
-Shared hook design guidance lives in
-[../skills/designing-hooks/SKILL.md](../skills/designing-hooks/SKILL.md).
+- Hook design guidance:
+  [../skills/designing-hooks/SKILL.md](../skills/designing-hooks/SKILL.md)
 
 ## Current Hooks
 
-`deny-dangerous-bash.mjs`
-: Event: `PreToolUse`
-: Tools: Codex `Bash|shell`; Claude `Bash`
-: Runs when: a shell command is about to run
-: Blocks: yes, exits `2` for destructive patterns
+| File                      | Event                              | Blocks / Feedback                                                 | Purpose                                                                                          |
+| ------------------------- | ---------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `before-bash.mjs`         | `PreToolUse` for Bash/shell        | Blocks on sub-hook failure                                        | Ordered shell-command guardrail; runs destructive-command checks before commit guardrails.       |
+| `deny-dangerous-bash.mjs` | `PreToolUse` via `before-bash.mjs` | Blocks with exit `2`                                              | Rejects destructive `rm -rf`, `git reset --hard`, force-push, and unparsable risky shell syntax. |
+| `sync-before-commit.mjs`  | `PreToolUse` via `before-bash.mjs` | Blocks commit on secret/adapter failures; MCP sync is best effort | Runs deterministic pre-commit guardrails only when the command is `git commit`.                  |
+| `after-edit.mjs`          | `PostToolUse` for edit tools       | Blocks on sub-hook failure                                        | Ordered edit guardrail; formats/lints before scoped test checks.                                 |
+| `format-and-lint.mjs`     | `PostToolUse` via `after-edit.mjs` | Blocks with exit `2` when auto-fix fails                          | Runs Prettier and ESLint fix for JS/TS edits outside ignored build folders.                      |
+| `test-changed.mjs`        | `PostToolUse` via `after-edit.mjs` | Blocks with exit `2` on scoped test failure                       | Runs the nearest workspace `test` script when a test/spec file changes.                          |
+| `inject-git-context.mjs`  | `UserPromptSubmit`                 | Non-blocking injected context                                     | Prints branch, dirty counts, and up to 10 short-status lines on every prompt.                    |
+| `stop-checks.mjs`         | `Stop`                             | Blocks on sub-hook failure                                        | Ordered stop guardrail; runs scoped typecheck before the task-context reminder.                  |
+| `typecheck-changed.mjs`   | `Stop` via `stop-checks.mjs`       | Blocks with exit `2` on scoped typecheck failure                  | Typechecks workspaces touched since `HEAD`, skipping recursive stop-hook runs.                   |
+| `check-task-context.mjs`  | `Stop` via `stop-checks.mjs`       | Advisory only                                                     | Reminds when `docs/CURRENT_TASK_CONTEXT.md` is missing or stale in a dirty worktree.             |
 
-`before-bash.mjs`
-: Event: `PreToolUse`
-: Tools: Codex `Bash|shell`; Claude `Bash`
-: Runs when: a shell command is about to run
-: Blocks: yes, runs `deny-dangerous-bash.mjs` before commit guardrails
+## Supporting Files
 
-`sync-before-commit.mjs`
-: Event: `PreToolUse`
-: Tools: Codex `Bash|shell`; Claude `Bash`
-: Runs when: command contains `git commit`
-: Blocks: yes for secret and adapter checks; MCP sync is best effort
+- `lib/hook-utils.mjs` reads hook input, detects the repo root, resolves edited
+  paths inside the repo, and maps sub-hook failures to exit `2`.
+- `lib/shell-command.mjs` wraps `shell-quote` and provides static parsing
+  helpers for newline-separated commands, wrapper commands such as
+  `bash -c`/`eval`, brace expansion, and env/sudo/git prefixes.
+- `deny-dangerous-bash.mjs` applies those helpers to fail closed on dangerous
+  `rm -rf` targets, unresolved command substitution or variable paths, broad
+  current-directory globs, hard resets, and force pushes.
 
-`after-edit.mjs`
-: Event: `PostToolUse`
-: Tools: Codex `Edit|MultiEdit|Write|apply_patch`; Claude `Edit|MultiEdit|Write`
-: Runs when: a file edit tool succeeds
-: Blocks/feedback: yes, runs format/lint before scoped test checks
+## Operating Rules
 
-`format-and-lint.mjs`
-: Event: `PostToolUse`
-: Tools: Codex `Edit|MultiEdit|Write|apply_patch`; Claude `Edit|MultiEdit|Write`
-: Runs when: edited file is JS/TS and not in ignored build folders
-: Blocks: yes, exits `2` if Prettier or ESLint cannot fix
+- Keep shared behavior in `.agents/hooks/*.mjs`; keep `.codex/hooks.json` and
+  `.claude/settings.json` as thin adapters.
+- Use orchestrator hooks when order matters. Do not rely on multiple handlers
+  in one lifecycle event to run sequentially.
+- Keep hooks deterministic, bounded, and repo-root safe. Do not add destructive
+  actions, hidden network calls, or broad writes.
+- `PreToolUse` can prevent an action. `PostToolUse` runs after the action and
+  can only feed back or continue the loop.
+- `Stop` hooks that can block must handle `stop_hook_active` or they can loop;
+  advisory-only Stop hooks (always exit `0`) are exempt.
 
-`test-changed.mjs`
-: Event: `PostToolUse`
-: Tools: same edit events as format/lint
-: Runs when: edited file is `*.test.*` or `*.spec.*` inside a package with `test`
-: Blocks: yes, returns the scoped test command status
+## Local Checks
 
-`inject-git-context.mjs`
-: Event: `UserPromptSubmit`
-: Tools: Codex and Claude
-: Runs when: every user prompt
-: Blocks: no, prints branch and short status as injected context
-
-`typecheck-changed.mjs`
-: Event: `Stop`
-: Tools: Codex and Claude
-: Runs when: Stop event, unless `stop_hook_active` is true
-: Blocks: yes, exits `2` when scoped typecheck fails
-
-`stop-checks.mjs`
-: Event: `Stop`
-: Tools: Codex and Claude
-: Runs when: Stop event
-: Blocks: yes, runs scoped typecheck before task-context guard
-
-`check-task-context.mjs`
-: Event: `Stop`
-: Tools: Codex and Claude
-: Runs when: dirty worktree at stop
-: Blocks: yes only when `docs/CURRENT_TASK_CONTEXT.md` is missing on first stop attempt; stale context is a warning
-
-## Adapter Notes
-
-- Codex supports `timeout` and `statusMessage` in `.codex/hooks.json`.
-- Codex currently skips command handlers marked with `async: true`; keep shared
-  command hooks synchronous unless the Codex adapter intentionally omits them.
-- Claude matcher strings such as `Edit|MultiEdit|Write` are exact alternatives.
-  Codex matchers in this repo use regular expressions for likely tool aliases.
-- Adapter commands must locate the repo root before invoking portable scripts.
-  Claude uses `$CLAUDE_PROJECT_DIR`; Codex assigns `git rev-parse --show-toplevel`
-  to `_root` before invoking `node "$_root/.agents/..."`.
-- Hook scripts also detect the repo root internally and run git/pnpm from there.
-- When order matters, adapters call one orchestrator hook instead of relying on
-  multiple handlers in the same lifecycle event.
-
-## Safety Properties Of The Shell-Command Parser
-
-`.agents/hooks/lib/shell-command.mjs` wraps `shell-quote` with extra closures
-that close known bypass vectors. The dangerous-command checks rely on these:
-
-- **Newline separator** — bash treats `\n` as a command terminator equivalent
-  to `;`. `shell-quote` does not emit a separator for newlines, so the parser
-  splits the input on `\n` before tokenizing each line independently.
-- **Wrapper commands** — `eval "<script>"`, `bash -c "<script>"`,
-  `sh -c "<script>"`, `zsh -c`, `dash -c`, `ksh -c`, `ash -c` are recursively
-  re-parsed (up to four levels) so a destructive command hidden inside a
-  wrapper string is still inspected.
-- **Brace expansion** — positionals like `/{etc,var}` or `{/,~}` are expanded
-  to all literal combinations before being matched against dangerous targets.
-- **Current-directory deletes** — `rm -rf .`, `rm -rf ./`, `rm -rf *`, and
-  similar broad current-directory globs are blocked because they can wipe the
-  active worktree.
-- **Unresolved targets** — when `rm -rf` is invoked with no positional or with
-  a positional that contains command substitution (`$(…)`, backticks), a
-  variable reference (`${HOME}`), or otherwise cannot be statically reduced
-  to a literal path, the hook fails closed.
-
-## Fail-Closed Orchestration
-
-`runNodeHook` in `.agents/hooks/lib/hook-utils.mjs` maps every non-success
-sub-hook outcome to exit `2` and prints the offending script and reason on
-stderr. This covers:
-
-- Spawn failures (missing/renamed sub-hook → `ENOENT`).
-- Signal kills (typically hook timeout → SIGTERM).
-- Unexpected exit codes (anything that is not `0` or `2`).
-
-A broken or missing sub-hook therefore surfaces as a real block instead of a
-silent pass. Each orchestrator also assigns per-phase timeouts so a stuck
-phase cannot exhaust the adapter's overall timeout budget.
-
-## Local Smoke Tests
-
-Use these commands to check hook parsing and core branches without invoking the
-full agent runtime.
+Use focused smoke tests when changing hook behavior:
 
 ```sh
 printf '%s' '{"tool_input":{"command":"git status"}}' \
@@ -133,54 +58,8 @@ printf '%s' '{"tool_input":{"command":"git status"}}' \
 printf '%s' '{"tool_input":{"command":"git reset --hard"}}' \
   | node .agents/hooks/before-bash.mjs
 
-printf '%s' '{"tool_input":{"command":"rm --recursive --force .git"}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"rm -rf ."}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"rm -rf *"}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"rm -rf .[!.]*"}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"echo \"rm -rf ~\""}}' \
-  | node .agents/hooks/before-bash.mjs
-
-# Bypass vectors closed by the parser wrapper — each should exit 2.
-printf '%s' '{"tool_input":{"command":"ls\nrm -rf /"}}' \
-  | node .agents/hooks/before-bash.mjs
-
 printf '%s' '{"tool_input":{"command":"bash -c \"rm -rf /\""}}' \
   | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"sudo bash -c \"rm -rf /\""}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"bash -lc \"rm -rf /\""}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"env FOO=1 sh -c \"git reset --hard\""}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"/usr/bin/env rm -rf /"}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"/usr/bin/env bash -lc \"rm -rf /\""}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"eval \"rm -rf ~\""}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"rm -rf {/,~}"}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"rm -rf $(pwd)"}}' \
-  | node .agents/hooks/before-bash.mjs
-
-printf '%s' '{"tool_input":{"command":"git status"}}' \
-  | node .agents/hooks/sync-before-commit.mjs
 
 printf '%s' '{"tool_input":{"command":"git commit -m test"}}' \
   | node .agents/hooks/sync-before-commit.mjs
@@ -188,36 +67,21 @@ printf '%s' '{"tool_input":{"command":"git commit -m test"}}' \
 printf '%s' '{"tool_input":{"file_path":"scripts/validate-changed.mjs"}}' \
   | node .agents/hooks/after-edit.mjs
 
-printf '%s' '{"tool_input":{"file_path":"workspaces/ai-engineering/llm-chat/tests/main.test.ts"}}' \
-  | node .agents/hooks/test-changed.mjs
-
-node .agents/hooks/inject-git-context.mjs
-
 printf '%s' '{"stop_hook_active":true}' \
   | node .agents/hooks/stop-checks.mjs
 
-printf '%s' '{"stop_hook_active":true}' \
-  | node .agents/hooks/check-task-context.mjs
-
-(cd workspaces/apps/shop-mvc-express && node ../../../.agents/hooks/inject-git-context.mjs)
+node .agents/hooks/inject-git-context.mjs
 ```
 
-Some smoke tests invoke `pnpm`. If sandboxed execution reports
-`[ERROR] fetch failed`, rerun the same validation in an environment where the
-package manager can access its cache/network.
-
-## Explicit Validation
-
-Broader changed-file validation is intentionally agent-callable instead of
-automatic on every edit or stop:
+Run the broader changed-file validation explicitly when needed (portable prompt:
+[../commands/validate-changed.md](../commands/validate-changed.md)):
 
 ```sh
 pnpm run validate:changed
 ```
 
-Claude can run this command without a permission prompt through
-`.claude/settings.json`, and the portable command prompt lives at
-[../commands/validate-changed.md](../commands/validate-changed.md).
+If a sandboxed run reports `[ERROR] fetch failed`, rerun where pnpm can reach
+its cache/network.
 
 ## References
 

--- a/.agents/hooks/check-task-context.mjs
+++ b/.agents/hooks/check-task-context.mjs
@@ -1,6 +1,6 @@
-// Stop hook: enforce docs/CURRENT_TASK_CONTEXT.md before the session ends.
-// Exits 2 (blocking) when the file is missing; nudges (exit 0) when stale.
-// stop_hook_active guard prevents an infinite loop on the second Stop attempt.
+// Stop hook: nudge to keep docs/CURRENT_TASK_CONTEXT.md fresh.
+// Advisory only — always exits 0. Emits a system message when the file is
+// missing or stale in a dirty worktree.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
@@ -40,12 +40,10 @@ const main = () => {
 
   const ctxPath = resolve(root, CTX);
   if (!existsSync(ctxPath)) {
-    // Already in a stop-hook retry loop — don't block indefinitely.
-    if (payload?.stop_hook_active) return 0;
-    process.stderr.write(
-      `[hook] ${CTX} is missing — create it before stopping. See ${SKILL_HINT}\n`,
+    writeSystemMessage(
+      `[hook] reminder: ${CTX} is missing — add a compact handoff if work continues across sessions. See ${SKILL_HINT}`,
     );
-    return 2;
+    return 0;
   }
 
   const ctxMtime = statSync(ctxPath).mtimeMs;

--- a/.agents/hooks/inject-git-context.mjs
+++ b/.agents/hooks/inject-git-context.mjs
@@ -5,7 +5,7 @@ import { execFileSync } from 'node:child_process';
 
 import { readStdinJson, repoRoot } from './lib/hook-utils.mjs';
 
-const MAX_STATUS_LINES = 20;
+const MAX_STATUS_LINES = 10;
 
 const git = (args, root) => {
   try {
@@ -15,20 +15,42 @@ const git = (args, root) => {
   }
 };
 
+const countDirty = (lines) => {
+  let staged = 0;
+  let unstaged = 0;
+  let untracked = 0;
+  for (const line of lines) {
+    const x = line[0];
+    const y = line[1];
+    if (x === '?' && y === '?') {
+      untracked += 1;
+      continue;
+    }
+    if (x && x !== ' ') staged += 1;
+    if (y && y !== ' ') unstaged += 1;
+  }
+  return { staged, unstaged, untracked };
+};
+
 const main = () => {
   const root = repoRoot(readStdinJson());
   const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], root) || '(detached)';
   const status = git(['status', '--short'], root);
   const lines = status ? status.split('\n') : [];
-  const shown = lines.slice(0, MAX_STATUS_LINES);
-  const overflow =
-    lines.length > MAX_STATUS_LINES ? `\n…(+${lines.length - MAX_STATUS_LINES} more)` : '';
 
   process.stdout.write('<git-context>\n');
   process.stdout.write(`branch: ${branch}\n`);
-  if (shown.length === 0) {
+  if (lines.length === 0) {
     process.stdout.write('status: clean\n');
   } else {
+    const { staged, unstaged, untracked } = countDirty(lines);
+    process.stdout.write(
+      `dirty: ${lines.length} files (staged ${staged}, unstaged ${unstaged}, untracked ${untracked})\n`,
+    );
+    const shown = lines.slice(0, MAX_STATUS_LINES);
+    const hidden = lines.length - shown.length;
+    const overflow =
+      hidden > 0 ? `\n…(+${hidden} more — run \`git status --short\` for full state)` : '';
     process.stdout.write(`status:\n${shown.join('\n')}${overflow}\n`);
   }
   process.stdout.write('</git-context>\n');

--- a/.agents/hooks/inject-git-context.mjs
+++ b/.agents/hooks/inject-git-context.mjs
@@ -9,7 +9,9 @@ const MAX_STATUS_LINES = 10;
 
 const git = (args, root) => {
   try {
-    return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+    // trimEnd, not trim: `git status --short` uses the leading column to mark
+    // unstaged-only changes (" M file"), and trimming the left side flips it to staged.
+    return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trimEnd();
   } catch {
     return '';
   }

--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -19,8 +19,8 @@ For AI-agent docs design rules (skills are canonical, adapters are thin, role sp
 
 ## Current Task Context Rule
 
-`docs/CURRENT_TASK_CONTEXT.md` is a **session-only file** — it is intentionally not committed to the repository. Create it if it does not exist; do not treat a missing file as an error or skip updating it because it is absent.
+`docs/CURRENT_TASK_CONTEXT.md` is a **session-only, gitignored local handoff file** — not a permanent audit trail and not part of any commit.
 
-After every meaningful codebase change, investigation, debugging session, review, or implementation step, create or update [docs/CURRENT_TASK_CONTEXT.md](../../docs/CURRENT_TASK_CONTEXT.md) using [skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md).
+Keep a compact handoff in [docs/CURRENT_TASK_CONTEXT.md](../../docs/CURRENT_TASK_CONTEXT.md) when work will continue across turns, tools, or sessions. Skip it for trivial or fully reverted edits, or when the next action is already obvious from the current diff. Create the file when needed; do not treat a missing file as an error.
 
-Keep `Current Focus` concise. Append timestamped entries to `Implementation Log`, `Decision Log`, and `Validation Log` using local ISO 8601 minute precision with timezone offset (for example `2026-04-25T14:32+02:00`). Do not delete or rewrite historical log entries; append a correction or follow-up entry instead. Record what changed, why, files touched, validation run, risks, and next steps. Do not include secrets, long logs, or full source code.
+Use [skills/current-task-context/SKILL.md](../skills/current-task-context/SKILL.md) for the file shape, update rules, and the `Activity Log` compaction rule (~120 lines). Use local ISO 8601 minute precision with timezone offset (for example `2026-05-18T16:32+02:00`) for log headings. Record what changed, why, files touched, validation run, risks, and next steps. Do not include secrets, long terminal logs, or full source code.

--- a/.agents/rules/repo-map.md
+++ b/.agents/rules/repo-map.md
@@ -13,6 +13,28 @@ Project-specific orientation for AI agents. Keep this file easy to edit when cop
 - Docs live under `docs/*`.
 - Shared AI-agent material lives under `.agents/*`. Tool-specific adapters live under `.claude/`, `.codex/`, `.cursor/`, or `.github/` and should stay thin (see [.agents/README.md](../README.md) for design rules).
 
+## Context Loading Policy
+
+Use the smallest context set that can answer the task safely.
+
+- **Always loaded:** repo entry rules, safety rules, this repo shape, current
+  task, and changed-file summary.
+- **Loaded on demand:** task-specific skills, target source files, nearby tests,
+  package manifests, relevant docs, and imported shared packages.
+- **Avoid unless explicitly needed:** historical handoff logs, generated output,
+  `docs/_todo/**`, dependency folders, binary or sample assets, broad roadmap
+  docs, and secret-bearing local config.
+
+For code tasks, inspect the target workspace, nearby tests, package manifest,
+and imported shared packages before broad docs. Prefer `git ls-files`,
+`git status --short <path>`, and focused `rg --files <path>` over broad `find`
+or unscoped status output.
+
+Load avoid-tier sources only when the task explicitly targets them. For Claude,
+use a subagent for broad independent research or verbose output, especially when
+more than a few file reads are needed. For Codex, keep broad shell output short
+and path-scoped because raw output stays in the conversation transcript.
+
 ## Apps
 
 - `workspaces/apps/shop-mvc-express`: Express backend app.

--- a/.agents/skills/current-task-context/SKILL.md
+++ b/.agents/skills/current-task-context/SKILL.md
@@ -1,43 +1,38 @@
 ---
 name: current-task-context
-description: Current task context handoff updates for docs/CURRENT_TASK_CONTEXT.md. Use after meaningful codebase changes, debugging, reviews, investigations, or handoffs.
+description: Current task context handoff updates for docs/CURRENT_TASK_CONTEXT.md. Use when work will continue across turns, tools, or sessions and a compact handoff would help the next agent.
 metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-05-05'
+  last-reviewed: '2026-05-18'
 ---
 
 # Current Task Context
 
 ## Purpose
 
-Keep `docs/CURRENT_TASK_CONTEXT.md` accurate as shared working memory and an audit trail for humans and AI tools.
+Keep `docs/CURRENT_TASK_CONTEXT.md` as a compact local handoff so another tool or session can pick up the current work without re-deriving context from scratch.
 
-Use this skill to capture the current state of work so another tool or session can continue without losing context, while preserving the history of meaningful implementation, decision, validation, and handoff events.
+The file is gitignored and session-only — it is shared working memory, not a permanent audit trail. Git history is the durable record; this file just carries what the next turn needs.
 
 ## When To Use
 
-Use after a meaningful:
+Update when work will continue across turns, tools, or sessions, after a meaningful:
 
-- implementation
-- refactor
-- debugging session
-- code review
-- test fix
-- architecture decision
-- dependency or config change
-- investigation that changes understanding of the codebase
+- implementation, refactor, or debugging step
+- review, investigation, or architecture decision
+- dependency, schema, or config change
+- validation run whose result informs the next action
 - PR or commit preparation step
 
 ## When Not To Use
 
-Do not update for:
+Skip the update for:
 
-- formatting-only edits
-- typo-only changes
+- formatting-only edits or typo fixes
 - temporary experiments that were fully reverted
-- duplicated information already captured in the latest entry
+- information already captured in the latest entry or trivially recoverable from `git diff` / `git log`
 
 ## Inputs
 
@@ -55,47 +50,32 @@ Do not guess missing facts. Mark unknowns clearly.
 ## Workflow
 
 1. Inspect the current diff, recent changes, and `git status`.
-2. Get a local timestamp at minute precision with timezone offset, for example `2026-04-25T14:32+02:00`.
-3. Identify only meaningful information worth handing off or preserving.
-4. Open `docs/CURRENT_TASK_CONTEXT.md`.
-5. Update `Current Focus` in place with the latest live state.
-6. Append new entries to `Implementation Log`, `Decision Log`, and `Validation Log` as needed.
-7. Record exact validation commands and real results.
-8. Update `Open Items` and `Handoff Summary` so the next AI or human session can continue.
-9. Report what was updated.
+2. Get a local timestamp at minute precision with timezone offset, for example `2026-05-18T16:32+02:00`.
+3. Identify only meaningful information worth handing off — skip anything recoverable from git.
+4. Open `docs/CURRENT_TASK_CONTEXT.md` (create it if missing).
+5. Update `Current Focus`, `Open Items`, `Risks / Watchouts`, and `Handoff Summary` in place.
+6. Append a typed entry to `Activity Log` if there is something worth preserving.
+7. Compact `Activity Log` when it grows past ~120 lines (see Update Rules).
+8. Report what was updated.
 
 ## Update Rules
 
-Prefer concise entries, but do not collapse history into a single latest summary.
+`Current Focus`, `Open Items`, `Risks / Watchouts`, and `Handoff Summary` are mutable sections. Keep them current and concise — they describe the live state, not history.
 
-`Current Focus`, `Open Items`, and `Handoff Summary` are mutable sections. Keep them current and concise.
-
-`Implementation Log`, `Decision Log`, and `Validation Log` are append-only sections. Do not delete, reorder, or rewrite historical entries just because newer work supersedes them. If an old entry is wrong, append a correction entry with a new timestamp. Archive old history only when explicitly asked.
-
-Use local ISO 8601 minute precision with timezone offset for log headings:
+`Activity Log` is append-mostly. Each entry has a typed heading with a local timestamp at minute precision and timezone offset:
 
 ```md
-### 2026-04-25T14:32+02:00 - Short title
+### 2026-05-18T16:32+02:00 - Short title (type)
 ```
 
-Seconds are unnecessary for manual updates. Automated tooling may include seconds if needed for uniqueness.
+Entry types: `implementation`, `decision`, `validation`, `review`, `blocker`, `rollback`, `handoff`, `docs`.
 
-Meaningful event types include:
+Compaction rule: when `Activity Log` exceeds ~120 lines, summarize or drop the oldest entries that no longer inform `Current Focus`, `Open Items`, `Risks`, or recent decisions. Do not drop entries that still load-bear for the next action. Git history remains the durable record — this file is a rolling working set, not an archive. If an old entry is wrong, append a corrected entry with a new timestamp rather than rewriting it in place.
 
-- implementation
-- review
-- validation
-- decision
-- blocker
-- rollback
-- handoff
-- docs update
-
-Good context answers these questions:
+Good context answers:
 
 - What is the task?
-- What changed?
-- Why did it change?
+- What changed and why?
 - Which files matter?
 - What was validated?
 - What remains risky or unfinished?
@@ -103,11 +83,11 @@ Good context answers these questions:
 
 Avoid:
 
-- long logs
+- long terminal logs
 - copied source code
 - secrets
 - speculation
-- duplicate commit messages
+- duplicating commit messages
 - generic notes like "improved code"
 
 ## Recommended `docs/CURRENT_TASK_CONTEXT.md` Shape
@@ -117,9 +97,7 @@ Use this structure. Skip empty sections.
 ```md
 # Current Task Context
 
-Shared working context for humans and AI agents.
-
-Current focus is the live handoff. Logs are historical and append-only.
+Local working context for humans and AI agents. Session-only, gitignored.
 
 ## Current Focus
 
@@ -129,33 +107,14 @@ Current focus is the live handoff. Logs are historical and append-only.
 - Next action:
 - Related files:
 
-## Implementation Log
+## Activity Log
 
-### YYYY-MM-DDTHH:mm+HH:MM - Short title
+### YYYY-MM-DDTHH:mm+HH:MM - Short title (type)
 
-- Type:
-- Status:
-- Actor:
-- Implemented:
+- Summary:
 - Files:
 - Validation:
 - Follow-up:
-
-## Decision Log
-
-### YYYY-MM-DDTHH:mm+HH:MM - Short title
-
-- Decision:
-- Reason:
-- Trade-off:
-
-## Validation Log
-
-### YYYY-MM-DDTHH:mm+HH:MM - Short title
-
-- Commands:
-- Result:
-- Notes:
 
 ## Open Items
 
@@ -194,64 +153,6 @@ Updated `docs/CURRENT_TASK_CONTEXT.md`.
 
 ## Example Entry
 
-```md
-## Current Focus
-
-- Task: Add backend API validation.
-- Status: Validation implemented and tested.
-- Current blocker: None.
-- Next action: Review error response shape.
-- Related files:
-  - `workspaces/apps/orders/src/routes/orders.ts`
-  - `workspaces/apps/orders/src/schemas/order.schema.ts`
-  - `workspaces/apps/orders/src/routes/orders.test.ts`
-
-## Implementation Log
-
-### 2026-04-25T14:32+02:00 - Add backend API validation
-
-- Type: implementation
-- Status: done
-- Actor: Codex
-- Implemented: Added request validation for the create order endpoint to prevent invalid payloads from reaching service logic.
-- Files:
-  - `workspaces/apps/orders/src/routes/orders.ts`
-  - `workspaces/apps/orders/src/schemas/order.schema.ts`
-  - `workspaces/apps/orders/src/routes/orders.test.ts`
-- Validation:
-  - `pnpm --filter orders test` - passed
-- Follow-up: Confirm error response shape matches project conventions.
-
-## Decision Log
-
-### 2026-04-25T14:32+02:00 - Keep validation at the route boundary
-
-- Decision: Keep validation at the route boundary.
-- Reason: Invalid input should be rejected before business logic.
-- Trade-off: Route layer has more schema code, but service layer stays cleaner.
-
-## Validation Log
-
-### 2026-04-25T14:32+02:00 - Validate order route changes
-
-- Commands:
-  - `pnpm --filter orders test`
-- Result: Passed.
-- Notes: Covered invalid quantity.
-
-## Risks / Watchouts
-
-- Risk: Existing clients may rely on loose validation.
-- Mitigation: Check API examples and update docs if needed.
-
-## Open Items
-
-- [ ] Update API docs if contract changed.
-
-## Handoff Summary
-
-- Current state: Validation is implemented and tested.
-- What changed: Invalid order payloads now return a validation error.
-- What remains: Confirm error shape matches project conventions.
-- Recommended next action: Review current diff and prepare commit.
-```
+For a concrete formatting example, open
+[references/example.md](references/example.md) only when the template above is
+not enough.

--- a/.agents/skills/current-task-context/references/example.md
+++ b/.agents/skills/current-task-context/references/example.md
@@ -1,0 +1,44 @@
+# Current Task Context — Example Entry
+
+This file is only a concrete formatting reference for
+`docs/CURRENT_TASK_CONTEXT.md`. The canonical workflow, rules, and template live
+in [../SKILL.md](../SKILL.md).
+
+```md
+## Current Focus
+
+- Task: Add backend API validation.
+- Status: Validation implemented and tested.
+- Current blocker: None.
+- Next action: Review error response shape.
+- Related files:
+  - `workspaces/apps/orders/src/routes/orders.ts`
+  - `workspaces/apps/orders/src/schemas/order.schema.ts`
+
+## Activity Log
+
+### 2026-05-18T14:32+02:00 - Add backend API validation (implementation)
+
+- Summary: Added request validation for the create order endpoint so invalid payloads are rejected before reaching service logic. Kept validation at the route boundary — service layer stays cleaner at the cost of more schema code in routes.
+- Files:
+  - `workspaces/apps/orders/src/routes/orders.ts`
+  - `workspaces/apps/orders/src/schemas/order.schema.ts`
+- Validation: `pnpm --filter orders test` — passed (covered invalid quantity).
+- Follow-up: Confirm error response shape matches project conventions.
+
+## Risks / Watchouts
+
+- Risk: Existing clients may rely on loose validation.
+- Mitigation: Check API examples and update docs if needed.
+
+## Open Items
+
+- [ ] Update API docs if contract changed.
+
+## Handoff Summary
+
+- Current state: Validation is implemented and tested.
+- What changed: Invalid order payloads now return a validation error.
+- What remains: Confirm error shape matches project conventions.
+- Recommended next action: Review current diff and prepare commit.
+```

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -51,7 +51,7 @@ Implement requested changes with the smallest practical diff while preserving ex
 6. Add or update tests for meaningful behavior changes.
 7. Update docs or examples when user-facing, setup, API, migration, or workflow behavior changes.
 8. Use [validate](../validate/SKILL.md) before finishing.
-9. Use [current-task-context](../current-task-context/SKILL.md) after meaningful implementation handoffs.
+9. Use [current-task-context](../current-task-context/SKILL.md) only when a handoff is useful — work continues across turns, tools, or sessions; defer to its `When To Use` / `When Not To Use`.
 
 ## Output Format
 

--- a/.claude/agents/backend-architect.md
+++ b/.claude/agents/backend-architect.md
@@ -1,6 +1,6 @@
 ---
 name: repo-backend-architect
-description: Use for backend architecture review, service boundaries, TypeScript layering, validation, and API/data design in this repo.
+description: Use for backend boundaries, TypeScript layering, validation, API/data design.
 tools: Read, Glob, Grep, Bash
 disallowedTools: Edit, MultiEdit, Write
 model: inherit
@@ -8,14 +8,8 @@ model: inherit
 
 You are the backend architecture subagent for this repository.
 
-Before giving advice, read the canonical project instructions:
+Before giving advice, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/backend-architect.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/backend-architect.md`
-
-Follow `.agents/agents/backend-architect.md` as the source of truth. Keep the
-work read-only and use Bash only for inspection or safe validation commands.
+Keep the work read-only and use Bash only for inspection or safe validation
+commands.

--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -1,6 +1,6 @@
 ---
 name: repo-code-review
-description: Use for read-only review of diffs, branches, PRs, commits, or files for bugs, regressions, security issues, test gaps, and maintainability risks.
+description: Use for read-only review of diffs, PRs, commits, files, bugs, security, test gaps, and maintainability risk.
 tools: Read, Glob, Grep, Bash
 disallowedTools: Edit, MultiEdit, Write
 model: inherit
@@ -8,15 +8,9 @@ model: inherit
 
 You are the code review subagent for this repository.
 
-Before reviewing, read the canonical project instructions:
+Before reviewing, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/code-review.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/code-review.md`
-
-Follow `.agents/agents/code-review.md` as the source of truth. Stay read-only:
-do not edit, format, stage, commit, push, deploy, or run destructive commands.
-Use Bash only for inspection, diff, and safe validation commands.
+Stay read-only: do not edit, format, stage, commit, push, deploy, or run
+destructive commands. Use Bash only for inspection, diff, and safe validation
+commands.

--- a/.claude/agents/debug.md
+++ b/.claude/agents/debug.md
@@ -8,15 +8,9 @@ model: inherit
 
 You are the debugging subagent for this repository.
 
-Before investigating, read the canonical project instructions:
+Before investigating, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/debug.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/debug.md`
-
-Follow `.agents/agents/debug.md` as the source of truth. Prefer focused
-reproduction, small validation commands, and clear evidence. Return the minimal
-fix direction; leave edits to an implementation agent unless explicitly assigned.
+Prefer focused reproduction, small validation commands, and clear evidence.
+Return the minimal fix direction; leave edits to an implementation agent unless
+explicitly assigned.

--- a/.claude/agents/delivery.md
+++ b/.claude/agents/delivery.md
@@ -1,20 +1,13 @@
 ---
 name: repo-delivery
-description: Use to prepare commits, PR descriptions, release-readiness summaries, and final handoff notes for this repo.
+description: Use to prepare commits, PR descriptions, release summaries, and handoff notes.
 tools: Read, Glob, Grep, Bash, Edit, MultiEdit, Write
 model: inherit
 ---
 
 You are the delivery subagent for this repository.
 
-Before preparing delivery material, read the canonical project instructions:
+Before preparing delivery material, read `AGENTS.md` for shared repo
+instructions and `.agents/agents/delivery.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/delivery.md`
-
-Follow `.agents/agents/delivery.md` as the source of truth. Do not stage,
-commit, push, tag, or publish unless the user explicitly asks.
+Do not stage, commit, push, tag, or publish unless the user explicitly asks.

--- a/.claude/agents/implement.md
+++ b/.claude/agents/implement.md
@@ -1,20 +1,14 @@
 ---
 name: repo-implement
-description: Use to implement focused code or documentation changes in this repo while preserving architecture, typing, tests, and existing behavior.
+description: Use to implement focused code/docs changes preserving architecture, typing, tests, and behavior.
 tools: Read, Glob, Grep, Bash, Edit, MultiEdit, Write
 model: inherit
 ---
 
 You are the implementation subagent for this repository.
 
-Before editing, read the canonical project instructions:
+Before editing, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/implement.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/implement.md`
-
-Follow `.agents/agents/implement.md` as the source of truth. Keep diffs focused,
-respect existing architecture, and run the smallest relevant validation.
+Keep diffs focused, respect existing architecture, and run the smallest relevant
+validation.

--- a/.claude/agents/plan.md
+++ b/.claude/agents/plan.md
@@ -8,17 +8,11 @@ model: inherit
 
 You are the planning subagent for this repository.
 
-Before planning, read the canonical project instructions:
+Before planning, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/plan.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/plan.md`
-
-Follow `.agents/agents/plan.md` as the source of truth. Produce a practical
-read-only plan that names files, commands, risks, and validation.
+Produce a practical read-only plan that names files, commands, risks, and
+validation.
 
 This subagent has no write tools. When delegated from an explicit `/plan` or
 written-plan request, return the proposed `docs/plan-<short-task-goal>.md` path

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -8,15 +8,9 @@ model: inherit
 
 You are the security review subagent for this repository.
 
-Before reviewing, read the canonical project instructions:
+Before reviewing, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/security-reviewer.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/security-reviewer.md`
-
-Follow `.agents/agents/security-reviewer.md` as the source of truth. Do not
-print secret values; identify only the file, location, and class of exposure.
-Stay read-only and use Bash only for inspection or safe validation commands.
+Do not print secret values; identify only the file, location, and class of
+exposure. Stay read-only and use Bash only for inspection or safe validation
+commands.

--- a/.claude/agents/task-analyst.md
+++ b/.claude/agents/task-analyst.md
@@ -8,14 +8,8 @@ model: inherit
 
 You are the task analysis subagent for this repository.
 
-Before analysis, read the canonical project instructions:
+Before analysis, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/task-analyst.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/task-analyst.md`
-
-Follow `.agents/agents/task-analyst.md` as the source of truth. Keep output
-concrete, stay read-only, and route to the smallest workflow that fits the task.
+Keep output concrete, stay read-only, and route to the smallest workflow that
+fits the task.

--- a/.claude/agents/tests.md
+++ b/.claude/agents/tests.md
@@ -1,6 +1,6 @@
 ---
 name: repo-tests
-description: Use to choose, run, interpret, or improve focused tests and validation for changes in this repo.
+description: Use to choose, run, interpret, or improve focused tests and validation.
 tools: Read, Glob, Grep, Bash
 disallowedTools: Edit, MultiEdit, Write
 model: inherit
@@ -8,15 +8,8 @@ model: inherit
 
 You are the testing and validation subagent for this repository.
 
-Before choosing validation, read the canonical project instructions:
+Before choosing validation, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/tests.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/tests.md`
-
-Follow `.agents/agents/tests.md` as the source of truth. Prefer focused
-validation first, then broader checks when safe. Stay read-only unless the user
-explicitly asks for test implementation.
+Prefer focused validation first, then broader checks when safe. Stay read-only
+unless the user explicitly asks for test implementation.

--- a/.claude/agents/update-docs.md
+++ b/.claude/agents/update-docs.md
@@ -1,23 +1,16 @@
 ---
 name: repo-update-docs
-description: Use to update README files, developer docs, API examples, setup notes, migration notes, or handoff context after repo changes.
+description: Use to update READMEs, developer docs, API examples, setup/migration notes, and handoff context.
 tools: Read, Glob, Grep, Bash, Edit, MultiEdit, Write
 model: inherit
 ---
 
 You are the documentation update subagent for this repository.
 
-Before editing docs, read the canonical project instructions:
+Before editing docs, read `AGENTS.md` for shared repo instructions and
+`.agents/agents/update-docs.md` for this role's source of truth. Follow it.
 
-- `AGENTS.md`
-- `.agents/README.md`
-- `.agents/rules/project.md`
-- `.agents/rules/repo-map.md`
-- `.agents/rules/change-discipline.md`
-- `.agents/agents/update-docs.md`
-
-Follow `.agents/agents/update-docs.md` as the source of truth and the
-`Freshness Window`, `AI-Agent Docs Layout`, and `AI-Agent Docs Review` sections
-in `.agents/skills/update-docs/SKILL.md` whenever AI-agent guidance is in
-scope. Keep portable guidance in `.agents/` and keep Claude-specific files as
-thin adapters.
+Follow the `Freshness Window`, `AI-Agent Docs Layout`, and `AI-Agent Docs
+Review` sections in `.agents/skills/update-docs/SKILL.md` whenever AI-agent
+guidance is in scope. Keep portable guidance in `.agents/` and keep
+Claude-specific files as thin adapters.

--- a/.claude/commands/improve-token-usage.md
+++ b/.claude/commands/improve-token-usage.md
@@ -1,0 +1,9 @@
+---
+description: Investigate repo context cost and produce a token-usage improvement plan.
+argument-hint: '[optional output path or focus]'
+---
+
+Read and execute `.agents/commands/improve-token-usage.md` as the canonical
+command body.
+
+Use `$ARGUMENTS` as the optional output path, scope, or focus note.

--- a/.claude/skills/current-task-context/SKILL.md
+++ b/.claude/skills/current-task-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: current-task-context
-description: Current task context handoff updates for docs/CURRENT_TASK_CONTEXT.md. Use after meaningful codebase changes, debugging, reviews, investigations, or handoffs.
+description: Current task context handoff updates for docs/CURRENT_TASK_CONTEXT.md. Use when work will continue across turns, tools, or sessions and a compact handoff would help the next agent.
 argument-hint: '[change, validation, or handoff summary]'
 ---
 
@@ -14,4 +14,4 @@ When this skill is selected:
 2. Read `.agents/README.md` and the rules under `.agents/rules/`.
 3. Read `.agents/skills/current-task-context/SKILL.md`.
 4. Follow the `.agents` skill as the source of truth.
-5. Keep the live focus concise, keep history logs append-only, and do not include secrets or long logs.
+5. Keep the live focus concise, follow the canonical `Activity Log` compaction rules, and do not include secrets or long logs.

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pnpm-debug.log*
 .mcp.json
 .codex/config.toml
 .playwright-mcp
+
+# Session-only AI-agent handoff state (kept local, never committed)
+docs/CURRENT_TASK_CONTEXT.md

--- a/workspaces/ai-engineering/claude-capabilities-lab/README.md
+++ b/workspaces/ai-engineering/claude-capabilities-lab/README.md
@@ -21,9 +21,12 @@ clients; **no live Anthropic calls are made in CI**.
 
 Sample assets live under `samples/` and are committed as small fixtures so the
 scenarios are runnable out of the box (images, a PDF, a CSV, and a text file).
+See [samples/MANIFEST.md](samples/MANIFEST.md) for filenames, sizes, and per-file
+purpose — AI agents should consult the manifest before opening any binary,
+PDF, image, large CSV, or generated output in this workspace.
 Replace them with your own files in `samples/images/`, `samples/documents/`,
-`samples/text/`, or `samples/data/` as needed. The lab validates file types and
-sizes before sending data to Anthropic.
+`samples/text/`, or `samples/data/` as needed (and update the manifest row when
+you do). The lab validates file types and sizes before sending data to Anthropic.
 
 Generated outputs are written under `outputs/` and ignored by git.
 

--- a/workspaces/ai-engineering/claude-capabilities-lab/samples/MANIFEST.md
+++ b/workspaces/ai-engineering/claude-capabilities-lab/samples/MANIFEST.md
@@ -1,0 +1,27 @@
+# Sample Asset Manifest
+
+Committed fixtures for the capability-lab scenarios. The files are real PNG, PDF, CSV, and text payloads — agents should consult this manifest **before** opening any binary, PDF, image, large CSV, or generated output in this workspace, and prefer passing paths to the scenario CLI documented in [../README.md](../README.md) over loading the bytes into context.
+
+## Files
+
+| Path                  | Type       | ~Size             | Purpose / When To Open                                                                                                             |
+| --------------------- | ---------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `data/streaming.csv`  | CSV        | 25 KB (501 lines) | Streaming-churn dataset for the Files API upload scenarios (`files upload`, `files chat`). Open only to verify the column schema.  |
+| `documents/earth.pdf` | PDF        | 866 KB            | PDF fixture for `cache`, `citations`, `pdf`, and document-vision scenarios. Pass the path to the scenario CLI — do not Read it.    |
+| `images/prop1.png`    | PNG image  | 710 KB            | Property photo used by vision and multimodal scenarios.                                                                            |
+| `images/prop2.png`    | PNG image  | 712 KB            | Property photo used by vision and multimodal scenarios.                                                                            |
+| `images/prop3.png`    | PNG image  | 716 KB            | Property photo used by vision and multimodal scenarios.                                                                            |
+| `images/prop4.png`    | PNG image  | 1.2 MB            | Property photo used by vision and multimodal scenarios (largest sample image).                                                     |
+| `images/prop5.png`    | PNG image  | 648 KB            | Property photo used by vision and multimodal scenarios.                                                                            |
+| `images/prop6.png`    | PNG image  | 687 KB            | Property photo used by vision and multimodal scenarios.                                                                            |
+| `images/prop7.png`    | PNG image  | 724 KB            | Property photo used by vision and multimodal scenarios.                                                                            |
+| `text/temp.txt`       | UTF-8 text | 25 KB (549 lines) | Long prompt fixture used by citations and text-document scenarios. Snippet-read with `offset` / `limit` when inspection is needed. |
+
+Combined sample payload: roughly 6.5 MB across 10 files. Treat the whole directory as on-demand context.
+
+## Agent Guidance
+
+- Inspect this manifest before opening any file under `samples/`. If the task only needs a path, do not load the bytes.
+- Keep these files in place — they are valid project fixtures referenced from [../README.md](../README.md) and [../tests](../tests).
+- Generated outputs under [../outputs](../outputs) are gitignored and should also be left unread by default.
+- When replacing a fixture with a personal asset (per [../README.md](../README.md)), update the matching row in this manifest so size and purpose stay accurate.


### PR DESCRIPTION
- Trim `.claude/agents/*.md` adapters to thin pointers; drop the redundant rules-file list and rely on AGENTS.md → `.agents/rules/` chain.
- Restructure `current-task-context` skill: collapse Implementation/Decision/ Validation logs into a single `Activity Log`, add the ~120-line compaction rule, and move the long example into `references/example.md` (loaded on demand).
- Tighten the task-context trigger: rewrite the skill description (`.agents/` + `.claude/`), `.agents/rules/project.md`, the `debug`/`implement`/`update-docs`/`validate-changed` command wrappers, and the implement skill link to fire only when a handoff is useful (work continues across turns, tools, or sessions).
- Make `check-task-context.mjs` advisory only — always exit 0, emit a Claude `systemMessage` JSON line (or Codex stderr fallback), and drop the `stop_hook_active` guard.
- Slim `inject-git-context.mjs` output: cap status at 10 lines, surface staged/unstaged/untracked counts on a `dirty:` line, and point to `git status --short` for overflow.
- Replace `.agents/hooks/README.md` runbook with a compact hook map plus Supporting Files / Operating Rules sections; keep a minimal smoke-test set.
- Add `Context Loading Policy` (always / on-demand / avoid tiers) to `.agents/rules/repo-map.md`.
- Add `improve-token-usage` command (`.agents/commands/` + `.claude/commands/`) for context-cost investigation and plan generation.
- Add `workspaces/ai-engineering/claude-capabilities lab/samples/MANIFEST.md.` with per-file paths, sizes, and purpose so agents can size context before opening binary/PDF/image assets; link from the lab README.
- Gitignore `docs/CURRENT_TASK_CONTEXT.md` (session-only local handoff state, never committed).