### PR TITLE
feat(mcp-chat): add document MCP chatbot workspace

### DIFF
--- a/.agents/rules/repo-map.md
+++ b/.agents/rules/repo-map.md
@@ -45,6 +45,7 @@ and path-scoped because raw output stays in the conversation transcript.
 ## AI Engineering
 
 - `workspaces/ai-engineering/llm-chat`: interactive LLM chat CLI built on `@workspaces/packages/llm-client`.
+- `workspaces/ai-engineering/mcp-chat`: document-focused MCP server + CLI MCP client/chatbot using the MCP TypeScript SDK V2 alpha. In-memory documents, streaming chat, `@doc_name` mentions, MCP-prompt slash commands.
 - `workspaces/ai-engineering/prompt-eval-lab`: automated prompt-evaluation CLI (dataset → render → run → grade) on top of `@workspaces/packages/llm-client`.
 - `workspaces/ai-engineering/rag-pipeline`: Express RAG retrieval service with VoyageAI embeddings, in-memory vector index, BM25 lexical index, and hybrid RRF retrieval. Consumed by `llm-chat` over HTTP through the optional `search_docs` tool.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,37 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))
 
+  workspaces/ai-engineering/mcp-chat:
+    dependencies:
+      '@cfworker/json-schema':
+        specifier: ^4.1.1
+        version: 4.1.1
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
+      '@workspaces/packages/llm-client':
+        specifier: workspace:*
+        version: link:../../packages/llm-client
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))
+
   workspaces/ai-engineering/prompt-eval-lab:
     dependencies:
       '@workspaces/packages/llm-client':
@@ -168,7 +199,7 @@ importers:
         version: 8.3.2(express@5.2.1)
       llm-checker:
         specifier: ^3.5.12
-        version: 3.5.12(@types/node@25.5.2)
+        version: 3.5.12(@cfworker/json-schema@4.1.1)(@types/node@25.5.2)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -318,6 +349,9 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -725,12 +759,30 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@modelcontextprotocol/client@2.0.0-alpha.2':
+    resolution: {integrity: sha512-FxlR5QyBPeCDEDPH2Kx20uygmuy9k2jh6ahUeEYtmVfUxboZZlUEUhn6w0XxnbxpkELcT1qyzTXC8Bqh3c8QUA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
       zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/server@2.0.0-alpha.2':
+    resolution: {integrity: sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -2552,6 +2604,8 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
+  '@cfworker/json-schema@4.1.1': {}
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -2811,7 +2865,18 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/client@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      jose: 6.2.2
+      pkce-challenge: 5.0.1
+      zod: 4.1.12
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0
@@ -2830,8 +2895,16 @@ snapshots:
       raw-body: 3.0.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      zod: 4.1.12
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
 
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
@@ -3979,9 +4052,9 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  llm-checker@3.5.12(@types/node@25.5.2):
+  llm-checker@3.5.12(@cfworker/json-schema@4.1.1)(@types/node@25.5.2):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       chalk: 4.1.2
       commander: 11.1.0
       inquirer: 8.2.7(@types/node@25.5.2)

--- a/workspaces/ai-engineering/README.md
+++ b/workspaces/ai-engineering/README.md
@@ -7,4 +7,5 @@ Examples build on top of [`@workspaces/packages/llm-client`](../packages/llm-cli
 ## Examples
 
 - [llm-chat](./llm-chat/) — interactive LLM chat CLI with multi-turn history, streaming, structured output formats (JSON/CSV/HTML), and optional Claude tool-use mode.
+- [mcp-chat](./mcp-chat/) — CLI chatbot paired with an in-memory document MCP server. Mention documents with `@doc_name`, run MCP prompts as `/format doc_id`, and verify tools/resources/prompts through MCP Inspector.
 - [prompt-eval-lab](./prompt-eval-lab/) — automated prompt-evaluation pipeline that loads a JSON dataset, calls the model, and grades each response with a model-based grader plus code-based syntax validators.

--- a/workspaces/ai-engineering/mcp-chat/.env.example
+++ b/workspaces/ai-engineering/mcp-chat/.env.example
@@ -1,0 +1,2 @@
+ANTHROPIC_API_KEY="your_key_here"
+ANTHROPIC_MODEL="claude-sonnet-4-6"

--- a/workspaces/ai-engineering/mcp-chat/.gitignore
+++ b/workspaces/ai-engineering/mcp-chat/.gitignore
@@ -1,0 +1,7 @@
+**/.env
+node_modules/
+dist/
+coverage/
+.env
+.env.*
+!.env.example

--- a/workspaces/ai-engineering/mcp-chat/README.md
+++ b/workspaces/ai-engineering/mcp-chat/README.md
@@ -1,0 +1,144 @@
+# mcp-chat
+
+A learning/demo workspace that pairs a small document-focused MCP server with a CLI MCP client/chatbot. The chatbot streams Claude responses, lets you mention documents with `@doc_name`, runs MCP prompts as slash commands (e.g. `/format plan.md`), and is intended for manual verification through both the CLI and the official [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector).
+
+## Scope (v1)
+
+- Single in-memory document store seeded in code.
+- One built-in MCP server (stdio) exposing two tools, two resources, and one prompt.
+- One CLI chatbot consuming the server via stdio.
+- No database, no persistence across restarts, no live API calls in tests.
+
+## SDK versions and protocol
+
+- MCP TypeScript SDK V2 packages (alpha) — pinned exactly:
+  - `@modelcontextprotocol/server@2.0.0-alpha.2`
+  - `@modelcontextprotocol/client@2.0.0-alpha.2`
+- Required optional peer dep: `@cfworker/json-schema@^4.1.1`. The SDK marks it as an optional peer, but the runtime imports it eagerly on alpha-2; installing it explicitly avoids `ERR_MODULE_NOT_FOUND`.
+- Target MCP protocol spec: `2025-11-25` (latest at time of writing).
+- Tool/resource/prompt schemas are built with `fromJsonSchema` plus `CfWorkerJsonSchemaValidator` from `@modelcontextprotocol/server`. We did not use Zod directly because Zod v4.1.12's `~standard` does not yet expose the `jsonSchema` converter the V2 alpha SDK requires.
+
+## Layout
+
+```
+src/
+  documents/         in-memory document store and seeds
+  server/            document MCP server + stdio entrypoint
+  client/            stdio MCP client wrapper
+  chat/              tool manager, prompt converter, document context, chat session
+  cli/               args parsing, readline, REPL loop, CLI entrypoint
+tests/
+  documents/         document store unit tests
+  server/            in-memory paired-transport integration tests
+  client/            MCP client wrapper tests
+  chat/              tool manager, prompt converter, chat session, document context
+  cli/               args parser and runChatbot integration tests
+  support/           shared in-memory paired transport for tests
+```
+
+## Tools, resources, prompts
+
+| Surface           | Name                        | Notes                                                                                  |
+| ----------------- | --------------------------- | -------------------------------------------------------------------------------------- |
+| Tool              | `read_doc_contents`         | Reads a document by id. Returns text + `structuredContent`.                            |
+| Tool              | `edit_document`             | Replaces a unique substring. Errors on missing doc, empty/missing/duplicate `old_str`. |
+| Resource          | `docs://documents`          | JSON list of all known document ids.                                                   |
+| Resource template | `docs://documents/{doc_id}` | Plain-text content of an individual document. Supports `list`.                         |
+| Prompt            | `format`                    | Instructs Claude to read the document and edit formatting issues if warranted.         |
+
+## Setup
+
+```bash
+cp .env.example .env
+# fill in ANTHROPIC_API_KEY
+pnpm install
+```
+
+`.env` reads `ANTHROPIC_API_KEY` and optional `ANTHROPIC_MODEL`. The model defaults to `DEFAULT_MODEL` from `@workspaces/packages/llm-client`.
+
+## Scripts
+
+```bash
+pnpm --filter mcp-chat typecheck   # tsc --noEmit
+pnpm --filter mcp-chat test        # vitest run
+pnpm --filter mcp-chat lint        # eslint src tests
+pnpm --filter mcp-chat build       # esbuild emit to dist/
+pnpm --filter mcp-chat server:dev  # tsx src/server/main.ts (stdio MCP server)
+pnpm --filter mcp-chat dev         # tsx src/cli/main.ts (CLI chatbot, dev mode)
+pnpm --filter mcp-chat server      # node dist/server/main.js
+pnpm --filter mcp-chat chat        # node dist/cli/main.js
+pnpm --filter mcp-chat inspect     # MCP Inspector against the built server
+```
+
+## CLI usage
+
+After `pnpm --filter mcp-chat build`, run:
+
+```bash
+pnpm --filter mcp-chat chat
+```
+
+Inside the REPL:
+
+- A plain prompt streams an assistant response token-by-token.
+- `@<doc_id>` in the prompt injects the document content into the user turn.
+- `@` (just the symbol) lists available documents.
+- `/<command>` runs the matching MCP prompt. `/` alone lists commands.
+- `/format <doc_id>` runs the `format` prompt for the given document and lets Claude call `read_doc_contents`/`edit_document`.
+- `exit` or `quit` leaves the REPL.
+
+CLI flags:
+
+| Flag               | Effect                                                                                                                                          |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--no-stream`      | Disable streaming. Print only the final assistant text.                                                                                         |
+| `--max-tokens <n>` | Override `maxTokens` per turn (default 1024).                                                                                                   |
+| `--server-dev`     | Launch the MCP server with `tsx` from TS source instead of `node dist/server/main.js`. Useful while iterating on the server without rebuilding. |
+| `--help`, `-h`     | Print usage.                                                                                                                                    |
+
+Document edits are **in-memory only** and are lost when the chat process exits.
+
+## MCP Inspector
+
+Inspector connects to the built server entrypoint and exposes the tools, resources, and prompts via a UI.
+
+```bash
+pnpm --filter mcp-chat build
+pnpm --filter mcp-chat inspect
+```
+
+Equivalent to:
+
+```bash
+npx -y @modelcontextprotocol/inspector node workspaces/ai-engineering/mcp-chat/dist/server/main.js
+```
+
+Inspector should never see stdout noise. The stdio entrypoint only writes diagnostics to stderr and prints no startup banner.
+
+## Manual test checklist
+
+In Inspector:
+
+- [ ] `tools/list` returns `read_doc_contents` and `edit_document`.
+- [ ] `read_doc_contents` with an existing `doc_id` returns text and `structuredContent`.
+- [ ] `read_doc_contents` with a missing `doc_id` returns `isError: true`.
+- [ ] `edit_document` with a unique `old_str` updates the document and reports `replacements: 1`.
+- [ ] `edit_document` errors clearly for missing doc, empty `old_str`, missing `old_str`, and multiple matches.
+- [ ] `resources/read` `docs://documents` returns the JSON list of ids.
+- [ ] `resources/read` `docs://documents/plan.md` returns the document text.
+- [ ] `prompts/list` includes `format`; `prompts/get` for `format` with `doc_id` returns the formatting instructions.
+
+In the CLI:
+
+- [ ] Plain prompt streams assistant text.
+- [ ] `@deposition.md` injects the document content into the user turn.
+- [ ] `@` lists documents; `/` lists commands.
+- [ ] `/format plan.md` runs the format prompt, shows MCP tool status lines, and prints a final summary.
+- [ ] Tool status lines and streamed assistant text remain readable side-by-side.
+
+## Risks and follow-ups
+
+- V2 SDK alpha: API surface and import paths may shift between releases. Pin exact versions and re-verify imports when upgrading.
+- The optional peer dependency `@cfworker/json-schema` is installed explicitly to work around eager runtime import in alpha-2.
+- Zod is intentionally not used in this workspace; revisit once Zod v4's `~standard.jsonSchema` lands.
+- Document persistence and multi-server registries are out of scope for v1.

--- a/workspaces/ai-engineering/mcp-chat/esbuild.config.mjs
+++ b/workspaces/ai-engineering/mcp-chat/esbuild.config.mjs
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { build } from 'esbuild';
+
+const packageJson = JSON.parse(readFileSync(path.resolve('package.json'), 'utf8'));
+const externalNpmDependencies = Object.keys(packageJson.dependencies ?? {}).filter(
+  (name) => !name.startsWith('@workspaces/'),
+);
+
+await build({
+  banner: {
+    js: "import { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);",
+  },
+  bundle: true,
+  entryPoints: ['src/server/main.ts', 'src/cli/main.ts'],
+  external: externalNpmDependencies,
+  format: 'esm',
+  outdir: 'dist',
+  outbase: 'src',
+  platform: 'node',
+  sourcemap: true,
+  target: 'node22',
+});

--- a/workspaces/ai-engineering/mcp-chat/package.json
+++ b/workspaces/ai-engineering/mcp-chat/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "mcp-chat",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "dev": "tsx src/cli/main.ts",
+    "server:dev": "tsx src/server/main.ts",
+    "server": "node dist/server/main.js",
+    "chat": "node dist/cli/main.js",
+    "inspect": "npx -y @modelcontextprotocol/inspector node dist/server/main.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src tests --ext .ts",
+    "build": "node esbuild.config.mjs"
+  },
+  "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@modelcontextprotocol/client": "2.0.0-alpha.2",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2",
+    "@workspaces/packages/llm-client": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "esbuild": "^0.28.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/workspaces/ai-engineering/mcp-chat/package.json
+++ b/workspaces/ai-engineering/mcp-chat/package.json
@@ -6,7 +6,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "dev": "tsx src/cli/main.ts",
+    "dev": "tsx src/cli/main.ts --server-dev",
     "server:dev": "tsx src/server/main.ts",
     "server": "node dist/server/main.js",
     "chat": "node dist/cli/main.js",

--- a/workspaces/ai-engineering/mcp-chat/src/chat/chat-session.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/chat/chat-session.ts
@@ -1,0 +1,138 @@
+import type {
+  ChatMessage,
+  LlmContentBlock,
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmToolDefinition,
+  LlmToolResultBlock,
+  LlmToolUseBlock,
+} from '@workspaces/packages/llm-client';
+
+import type { McpToolManager } from './mcp-tool-manager.js';
+import type { ChatOptions, Messages } from './types.js';
+
+export const DEFAULT_MAX_TOKENS = 1024;
+export const DEFAULT_MAX_TOOL_ROUNDS = 5;
+export const DEFAULT_MAX_PAUSE_CONTINUATIONS = 5;
+
+export interface ChatSessionConfig {
+  readonly defaultMaxTokens?: number;
+  readonly model: string;
+  readonly provider: LlmProvider;
+  readonly systemPrompt?: string;
+  readonly temperature?: number;
+  readonly toolManager: McpToolManager;
+}
+
+export interface ChatSession {
+  appendMessages(messages: readonly ChatMessage[]): void;
+  readonly history: Messages;
+  sendUserMessage(text: string, options?: ChatOptions): Promise<string>;
+}
+
+function extractToolUseBlocks(content: readonly LlmContentBlock[]): LlmToolUseBlock[] {
+  return content.filter((block): block is LlmToolUseBlock => block.type === 'tool_use');
+}
+
+function contentFromResponse(response: LlmResponse): readonly LlmContentBlock[] {
+  return response.content ?? [{ text: response.text, type: 'text' }];
+}
+
+function createPauseContinuationLimitError(): Error {
+  return new Error(
+    `Provider returned pause_turn more than ${String(DEFAULT_MAX_PAUSE_CONTINUATIONS)} times.`,
+  );
+}
+
+export function createChatSession(config: ChatSessionConfig): ChatSession {
+  const history: Messages = [];
+  const defaultMaxTokens = config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+
+  function buildRequest(options: ChatOptions): LlmRequest {
+    const tools: readonly LlmToolDefinition[] = config.toolManager.toolDefinitions();
+
+    return {
+      maxTokens: options.maxTokens ?? defaultMaxTokens,
+      messages: history,
+      model: config.model,
+      stream: options.stream ?? true,
+      ...(tools.length > 0 ? { tools } : {}),
+      ...(options.onTextDelta === undefined ? {} : { onTextDelta: options.onTextDelta }),
+      ...(options.outputFormat === undefined ? {} : { outputFormat: options.outputFormat }),
+      ...(config.systemPrompt === undefined ? {} : { systemPrompt: config.systemPrompt }),
+      ...(config.temperature === undefined ? {} : { temperature: config.temperature }),
+    };
+  }
+
+  return {
+    appendMessages(messages) {
+      history.push(...messages);
+    },
+    get history() {
+      return history;
+    },
+    async sendUserMessage(text, options = {}) {
+      history.push({ content: text, role: 'user' });
+      const maxToolRounds = options.maxToolRounds ?? DEFAULT_MAX_TOOL_ROUNDS;
+      let pauseContinuations = 0;
+      let toolRounds = 0;
+
+      while (true) {
+        const response = await config.provider.createMessage(buildRequest(options));
+        const assistantContent = contentFromResponse(response);
+
+        if (response.stopReason === 'pause_turn') {
+          if (pauseContinuations >= DEFAULT_MAX_PAUSE_CONTINUATIONS) {
+            throw createPauseContinuationLimitError();
+          }
+
+          history.push({ content: assistantContent, role: 'assistant' });
+          pauseContinuations += 1;
+          continue;
+        }
+
+        if (response.stopReason !== 'tool_use') {
+          history.push({ content: assistantContent, role: 'assistant' });
+          options.onToolEvent?.({ type: 'final_response_received' });
+
+          return response.text;
+        }
+
+        history.push({ content: assistantContent, role: 'assistant' });
+
+        const toolUseBlocks = extractToolUseBlocks(assistantContent);
+
+        if (toolUseBlocks.length === 0) {
+          throw new Error('Provider returned tool_use without any tool_use content blocks.');
+        }
+
+        if (toolRounds >= maxToolRounds) {
+          throw new Error(`Tool use exceeded the maximum round limit of ${String(maxToolRounds)}.`);
+        }
+
+        for (const toolUse of toolUseBlocks) {
+          options.onToolEvent?.({ toolName: toolUse.name, type: 'tool_requested' });
+        }
+
+        const results: LlmToolResultBlock[] = [];
+
+        for (const toolUse of toolUseBlocks) {
+          options.onToolEvent?.({ toolName: toolUse.name, type: 'tool_running' });
+
+          const result = await config.toolManager.callTool(toolUse);
+
+          options.onToolEvent?.({
+            toolName: toolUse.name,
+            type: result.is_error === true ? 'tool_failed' : 'tool_succeeded',
+          });
+          results.push(result);
+        }
+
+        history.push({ content: results, role: 'user' });
+        options.onToolEvent?.({ count: results.length, type: 'tool_results_submitted' });
+        toolRounds += 1;
+      }
+    },
+  };
+}

--- a/workspaces/ai-engineering/mcp-chat/src/chat/document-context.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/chat/document-context.ts
@@ -1,0 +1,115 @@
+import type { McpStdioClient } from '../client/mcp-client.js';
+
+const DOCUMENT_RESOURCE_PREFIX = 'docs://documents/';
+const DOCUMENTS_LIST_URI = 'docs://documents';
+
+export interface DocumentSnippet {
+  readonly content: string;
+  readonly docId: string;
+}
+
+export interface DocumentContextResult {
+  readonly snippets: readonly DocumentSnippet[];
+  readonly unknown: readonly string[];
+}
+
+function normalizeMentionToken(value: string): string {
+  return value.replaceAll(/\.+$/g, '');
+}
+
+export function extractDocumentMentions(text: string): readonly string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const match of text.matchAll(/@([\w./-]+)/g)) {
+    const value = match[1] === undefined ? undefined : normalizeMentionToken(match[1]);
+
+    if (value !== undefined && value !== '' && !seen.has(value)) {
+      seen.add(value);
+      ordered.push(value);
+    }
+  }
+
+  return ordered;
+}
+
+interface DocumentsListPayload {
+  documents?: unknown;
+}
+
+function parseDocumentList(text: string): readonly string[] {
+  let payload: DocumentsListPayload;
+
+  try {
+    payload = JSON.parse(text) as DocumentsListPayload;
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(payload.documents)) {
+    return [];
+  }
+
+  return payload.documents.filter((id): id is string => typeof id === 'string');
+}
+
+export async function listKnownDocumentIds(client: McpStdioClient): Promise<readonly string[]> {
+  const result = await client.readResource(DOCUMENTS_LIST_URI);
+
+  for (const content of result.contents) {
+    if ('text' in content && typeof content.text === 'string') {
+      return parseDocumentList(content.text);
+    }
+  }
+
+  return [];
+}
+
+export async function resolveMentions(
+  client: McpStdioClient,
+  text: string,
+): Promise<DocumentContextResult> {
+  const mentions = extractDocumentMentions(text);
+
+  if (mentions.length === 0) {
+    return { snippets: [], unknown: [] };
+  }
+
+  const known = new Set(await listKnownDocumentIds(client));
+  const snippets: DocumentSnippet[] = [];
+  const unknown: string[] = [];
+
+  for (const docId of mentions) {
+    if (!known.has(docId)) {
+      unknown.push(docId);
+      continue;
+    }
+
+    const result = await client.readResource(`${DOCUMENT_RESOURCE_PREFIX}${docId}`);
+    const textContent = result.contents.find(
+      (content): content is { text: string; uri: string; mimeType?: string } =>
+        'text' in content && typeof content.text === 'string',
+    );
+
+    if (textContent !== undefined) {
+      snippets.push({ content: textContent.text, docId });
+    }
+  }
+
+  return { snippets, unknown };
+}
+
+export function buildUserTextWithContext(
+  userText: string,
+  snippets: readonly DocumentSnippet[],
+): string {
+  if (snippets.length === 0) {
+    return userText;
+  }
+
+  const blocks = snippets.map(
+    (snippet) => `<document id="${snippet.docId}">\n${snippet.content}\n</document>`,
+  );
+
+  return ['Referenced documents:', ...blocks, '', 'User message:', userText].join('\n');
+}

--- a/workspaces/ai-engineering/mcp-chat/src/chat/mcp-tool-manager.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/chat/mcp-tool-manager.ts
@@ -1,0 +1,146 @@
+import type {
+  LlmCustomToolDefinition,
+  LlmToolInputSchema,
+  LlmToolResultBlock,
+  LlmToolUseBlock,
+} from '@workspaces/packages/llm-client';
+
+import type { McpCallToolResult, McpStdioClient, McpTool } from '../client/mcp-client.js';
+
+export interface RegisteredMcpClient {
+  readonly client: McpStdioClient;
+  readonly name: string;
+  readonly tools: readonly McpTool[];
+}
+
+export interface McpToolManager {
+  readonly clients: readonly RegisteredMcpClient[];
+  callTool(toolUse: LlmToolUseBlock): Promise<LlmToolResultBlock>;
+  toolDefinitions(): readonly LlmCustomToolDefinition[];
+}
+
+function toLlmInputSchema(schema: McpTool['inputSchema']): LlmToolInputSchema {
+  const { properties, required, type, ...rest } = schema;
+  void type;
+
+  return {
+    type: 'object',
+    ...rest,
+    ...(properties === undefined ? {} : { properties }),
+    ...(required === undefined ? {} : { required }),
+  };
+}
+
+function toLlmToolDefinitions(tools: readonly McpTool[]): readonly LlmCustomToolDefinition[] {
+  return tools.map((tool) => ({
+    ...(tool.description === undefined ? {} : { description: tool.description }),
+    inputSchema: toLlmInputSchema(tool.inputSchema),
+    name: tool.name,
+  }));
+}
+
+function callToolResultToToolResultBlock(
+  toolUseId: string,
+  result: McpCallToolResult,
+): LlmToolResultBlock {
+  const textChunks: string[] = [];
+
+  for (const block of result.content) {
+    if (block.type === 'text') {
+      textChunks.push(block.text);
+    } else if (block.type === 'resource' && 'text' in block.resource) {
+      textChunks.push(block.resource.text);
+    } else {
+      textChunks.push(`[unsupported tool content type: ${block.type}]`);
+    }
+  }
+
+  if (result.structuredContent !== undefined && textChunks.length === 0) {
+    textChunks.push(JSON.stringify(result.structuredContent));
+  }
+
+  const content = textChunks.length > 0 ? textChunks.join('\n') : '(empty tool result)';
+  const isError = result.isError === true;
+
+  return {
+    content,
+    tool_use_id: toolUseId,
+    type: 'tool_result',
+    ...(isError ? { is_error: true } : {}),
+  };
+}
+
+export interface CreateMcpToolManagerOptions {
+  readonly clients: readonly {
+    readonly client: McpStdioClient;
+    readonly name: string;
+  }[];
+}
+
+export async function createMcpToolManager(
+  options: CreateMcpToolManagerOptions,
+): Promise<McpToolManager> {
+  const registered: RegisteredMcpClient[] = [];
+  const seenNames = new Set<string>();
+
+  for (const entry of options.clients) {
+    const tools = await entry.client.listTools();
+
+    for (const tool of tools) {
+      if (seenNames.has(tool.name)) {
+        throw new Error(
+          `MCP tool "${tool.name}" is registered by more than one server. Tool names must be unique.`,
+        );
+      }
+
+      seenNames.add(tool.name);
+    }
+
+    registered.push({ client: entry.client, name: entry.name, tools });
+  }
+
+  const ownerByTool = new Map<string, RegisteredMcpClient>();
+
+  for (const entry of registered) {
+    for (const tool of entry.tools) {
+      ownerByTool.set(tool.name, entry);
+    }
+  }
+
+  return {
+    async callTool(toolUse) {
+      const owner = ownerByTool.get(toolUse.name);
+
+      if (owner === undefined) {
+        return {
+          content: `Unknown MCP tool: ${toolUse.name}`,
+          is_error: true,
+          tool_use_id: toolUse.id,
+          type: 'tool_result',
+        };
+      }
+
+      try {
+        const result = await owner.client.callTool(
+          toolUse.name,
+          (toolUse.input as Record<string, unknown> | null) ?? {},
+        );
+
+        return callToolResultToToolResultBlock(toolUse.id, result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        return {
+          content: `MCP tool "${toolUse.name}" threw: ${message}`,
+          is_error: true,
+          tool_use_id: toolUse.id,
+          type: 'tool_result',
+        };
+      }
+    },
+    clients: registered,
+    toolDefinitions() {
+      return registered.flatMap((entry) => toLlmToolDefinitions(entry.tools));
+    },
+  };
+}

--- a/workspaces/ai-engineering/mcp-chat/src/chat/prompt-converter.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/chat/prompt-converter.ts
@@ -1,0 +1,23 @@
+import type { ChatMessage } from '@workspaces/packages/llm-client';
+
+import type { McpGetPromptResult } from '../client/mcp-client.js';
+
+export function mcpPromptToChatMessages(prompt: McpGetPromptResult): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+
+  for (const message of prompt.messages) {
+    const block = message.content;
+
+    if (block.type === 'text') {
+      messages.push({ content: block.text, role: message.role });
+      continue;
+    }
+
+    if (block.type === 'resource' && 'text' in block.resource) {
+      messages.push({ content: block.resource.text, role: message.role });
+      continue;
+    }
+  }
+
+  return messages;
+}

--- a/workspaces/ai-engineering/mcp-chat/src/chat/types.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/chat/types.ts
@@ -1,0 +1,22 @@
+import type { OutputFormatConfig, TextDeltaHandler } from '@workspaces/packages/llm-client';
+
+export type { ChatMessage, Messages } from '@workspaces/packages/llm-client';
+
+export type ToolEvent =
+  | { readonly toolName: string; readonly type: 'tool_requested' }
+  | { readonly toolName: string; readonly type: 'tool_running' }
+  | { readonly toolName: string; readonly type: 'tool_succeeded' }
+  | { readonly toolName: string; readonly type: 'tool_failed' }
+  | { readonly count: number; readonly type: 'tool_results_submitted' }
+  | { readonly type: 'final_response_received' };
+
+export type ToolEventHandler = (event: ToolEvent) => void;
+
+export interface ChatOptions {
+  maxTokens?: number;
+  maxToolRounds?: number;
+  onTextDelta?: TextDeltaHandler;
+  onToolEvent?: ToolEventHandler;
+  outputFormat?: OutputFormatConfig;
+  stream?: boolean;
+}

--- a/workspaces/ai-engineering/mcp-chat/src/cli/args.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/cli/args.ts
@@ -1,0 +1,78 @@
+export interface ParsedArgs {
+  readonly maxTokens?: number;
+  readonly shouldPrintHelp: boolean;
+  readonly stream: boolean;
+  readonly useDevServer: boolean;
+}
+
+export function helpText(): string {
+  return [
+    'Usage: mcp-chat [options]',
+    '',
+    'Options:',
+    '  --help, -h             Print this help text and exit.',
+    '  --no-stream            Disable assistant streaming output.',
+    '  --max-tokens <n>       Maximum tokens per assistant response (default 1024).',
+    '  --server-dev           Launch the MCP server with tsx (TypeScript source).',
+    '',
+    'Built-in commands inside the REPL:',
+    '  /                      List available MCP prompts/commands.',
+    '  @                      List available document ids.',
+    '  /format <doc_id>       Run the format prompt for the given document.',
+    '  @<doc_id>              Mention a document to include its content in the next turn.',
+    '  exit                   Exit the chatbot.',
+  ].join('\n');
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  let stream = true;
+  let useDevServer = false;
+  let maxTokens: number | undefined;
+  let shouldPrintHelp = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--help' || arg === '-h') {
+      shouldPrintHelp = true;
+      continue;
+    }
+
+    if (arg === '--no-stream') {
+      stream = false;
+      continue;
+    }
+
+    if (arg === '--server-dev') {
+      useDevServer = true;
+      continue;
+    }
+
+    if (arg === '--max-tokens') {
+      const next = argv[i + 1];
+
+      if (next === undefined) {
+        throw new Error('--max-tokens requires a numeric argument.');
+      }
+
+      const parsed = Number(next);
+
+      if (!/^\d+$/.test(next) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+        throw new Error(`--max-tokens must be a positive integer, got "${next}".`);
+      }
+
+      maxTokens = parsed;
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${String(arg)}`);
+  }
+
+  return {
+    ...(maxTokens === undefined ? {} : { maxTokens }),
+    shouldPrintHelp,
+    stream,
+    useDevServer,
+  };
+}

--- a/workspaces/ai-engineering/mcp-chat/src/cli/main.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/cli/main.ts
@@ -1,0 +1,129 @@
+import { createProvider, loadConfig, loadEnvironment } from '@workspaces/packages/llm-client';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createChatSession } from '../chat/chat-session.js';
+import { listKnownDocumentIds } from '../chat/document-context.js';
+import { createMcpToolManager } from '../chat/mcp-tool-manager.js';
+import { connectMcpStdioClient } from '../client/mcp-client.js';
+import { helpText, parseArgs } from './args.js';
+import { createReadlineInput } from './readline.js';
+import { runChatbot } from './run-chatbot.js';
+
+const SYSTEM_PROMPT = [
+  'You are an assistant that helps the user reason about a small set of in-memory documents.',
+  'Use the MCP tools (read_doc_contents, edit_document) when they are useful.',
+  'When the user mentions @<doc_id>, the referenced document is included in the user turn.',
+].join(' ');
+
+const WORKSPACE_ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+
+function resolveServerCommand(useDevServer: boolean): {
+  args: readonly string[];
+  command: string;
+} {
+  if (useDevServer) {
+    return {
+      args: [path.join(WORKSPACE_ROOT, 'src/server/main.ts')],
+      command: path.join(WORKSPACE_ROOT, 'node_modules/.bin/tsx'),
+    };
+  }
+
+  return { args: [path.join(WORKSPACE_ROOT, 'dist/server/main.js')], command: process.execPath };
+}
+
+function buildCompleter(documents: readonly string[], prompts: readonly string[]) {
+  return (line: string): readonly [readonly string[], string] => {
+    if (line.startsWith('/')) {
+      const prefix = line.slice(1);
+      const hits = prompts.filter((name) => name.startsWith(prefix)).map((name) => `/${name}`);
+
+      return [hits, line];
+    }
+
+    if (line.startsWith('@')) {
+      const prefix = line.slice(1);
+      const hits = documents.filter((id) => id.startsWith(prefix)).map((id) => `@${id}`);
+
+      return [hits, line];
+    }
+
+    return [[], line];
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  if (parsed.shouldPrintHelp) {
+    console.log(helpText());
+
+    return;
+  }
+
+  loadEnvironment(path.join(WORKSPACE_ROOT, '.env'));
+  const config = loadConfig();
+  const provider = createProvider(config);
+
+  const { args, command } = resolveServerCommand(parsed.useDevServer);
+  const documentServer = await connectMcpStdioClient({
+    server: {
+      args: [...args],
+      command,
+      cwd: WORKSPACE_ROOT,
+    },
+  });
+
+  try {
+    const toolManager = await createMcpToolManager({
+      clients: [
+        {
+          client: documentServer,
+          name: 'document-mcp-server',
+        },
+      ],
+    });
+
+    const session = createChatSession({
+      model: config.model,
+      provider,
+      systemPrompt: SYSTEM_PROMPT,
+      temperature: 0.2,
+      toolManager,
+    });
+
+    const [documents, prompts] = await Promise.all([
+      listKnownDocumentIds(documentServer),
+      documentServer.listPrompts(),
+    ]);
+
+    const input = createReadlineInput({
+      completer: buildCompleter(
+        documents,
+        prompts.map((p) => p.name),
+      ),
+    });
+
+    try {
+      await runChatbot({
+        documentServer,
+        input: (prompt) => input.ask(prompt),
+        session,
+        stream: parsed.stream,
+        ...(parsed.maxTokens === undefined ? {} : { maxTokens: parsed.maxTokens }),
+      });
+    } finally {
+      input.close();
+    }
+  } finally {
+    await documentServer.close();
+  }
+}
+
+export function isDirectExecution(moduleUrl: string, entrypointPath: string | undefined): boolean {
+  return entrypointPath !== undefined && fileURLToPath(moduleUrl) === path.resolve(entrypointPath);
+}
+
+if (isDirectExecution(import.meta.url, process.argv[1])) {
+  await main();
+}

--- a/workspaces/ai-engineering/mcp-chat/src/cli/readline.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/cli/readline.ts
@@ -1,0 +1,57 @@
+import { stdin, stdout } from 'node:process';
+import { createInterface } from 'node:readline';
+
+export interface InputAdapter {
+  ask(prompt: string): Promise<string>;
+  close(): void;
+}
+
+export interface ReadlineInputOptions {
+  readonly completer?: (line: string) => readonly [readonly string[], string];
+  readonly input?: NodeJS.ReadableStream;
+  readonly output?: NodeJS.WritableStream;
+}
+
+export function createReadlineInput(options: ReadlineInputOptions = {}): InputAdapter {
+  const readline = createInterface({
+    input: options.input ?? stdin,
+    output: options.output ?? stdout,
+    ...(options.completer === undefined
+      ? {}
+      : {
+          completer: (line: string): [string[], string] => {
+            const [completions, prefix] = options.completer!(line);
+
+            return [[...completions], prefix];
+          },
+        }),
+  });
+
+  let isClosed = false;
+  let pendingReject: ((error: Error) => void) | undefined;
+
+  readline.on('close', () => {
+    isClosed = true;
+    pendingReject?.(new Error('Readline input closed'));
+    pendingReject = undefined;
+  });
+
+  return {
+    ask(prompt) {
+      if (isClosed) {
+        return Promise.reject(new Error('Readline input closed'));
+      }
+
+      return new Promise<string>((resolve, reject) => {
+        pendingReject = reject;
+        readline.question(prompt, (answer) => {
+          pendingReject = undefined;
+          resolve(answer);
+        });
+      });
+    },
+    close() {
+      readline.close();
+    },
+  };
+}

--- a/workspaces/ai-engineering/mcp-chat/src/cli/run-chatbot.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/cli/run-chatbot.ts
@@ -1,0 +1,241 @@
+import type { ChatSession } from '../chat/chat-session.js';
+import {
+  buildUserTextWithContext,
+  listKnownDocumentIds,
+  resolveMentions,
+} from '../chat/document-context.js';
+import { mcpPromptToChatMessages } from '../chat/prompt-converter.js';
+import type { ChatOptions, ToolEvent } from '../chat/types.js';
+import type { McpStdioClient } from '../client/mcp-client.js';
+
+export type InputFunction = (prompt: string) => Promise<string>;
+export type OutputFunction = (text: string) => void;
+export type OutputChunkFunction = (text: string) => void;
+
+export interface RunChatbotOptions {
+  readonly documentServer: McpStdioClient;
+  readonly input: InputFunction;
+  readonly maxTokens?: number;
+  readonly output?: OutputFunction;
+  readonly outputChunk?: OutputChunkFunction;
+  readonly session: ChatSession;
+  readonly stream?: boolean;
+}
+
+function formatToolEvent(event: ToolEvent): string | undefined {
+  if (event.type === 'tool_requested') {
+    return `[tool] Claude requested ${event.toolName}`;
+  }
+
+  if (event.type === 'tool_running') {
+    return `[tool] Running ${event.toolName}`;
+  }
+
+  if (event.type === 'tool_succeeded') {
+    return `[tool] ${event.toolName} succeeded`;
+  }
+
+  if (event.type === 'tool_failed') {
+    return `[tool] ${event.toolName} failed`;
+  }
+
+  if (event.type === 'tool_results_submitted') {
+    return event.count === 1
+      ? '[tool] Sending tool result to Claude'
+      : '[tool] Sending tool results to Claude';
+  }
+
+  return undefined;
+}
+
+async function listAvailableCommands(client: McpStdioClient): Promise<readonly string[]> {
+  const prompts = await client.listPrompts();
+
+  return prompts.map((prompt) => prompt.name);
+}
+
+function parseSlashCommand(input: string): { args: string[]; name: string } | undefined {
+  const trimmed = input.trim();
+
+  if (!trimmed.startsWith('/')) {
+    return undefined;
+  }
+
+  const tokens = trimmed.slice(1).split(/\s+/).filter(Boolean);
+
+  if (tokens.length === 0) {
+    return undefined;
+  }
+
+  return { args: tokens.slice(1), name: tokens[0]! };
+}
+
+function buildPromptArgsRecord(
+  promptName: string,
+  args: readonly string[],
+  declared: readonly { name: string; required?: boolean | undefined }[] | undefined,
+): Record<string, string> {
+  if (declared === undefined || declared.length === 0) {
+    return {};
+  }
+
+  const out: Record<string, string> = {};
+
+  for (const [index, declaration] of declared.entries()) {
+    const value = args[index];
+
+    if (value !== undefined) {
+      out[declaration.name] = value;
+      continue;
+    }
+
+    if (declaration.required === true) {
+      throw new Error(
+        `/${promptName} requires argument "${declaration.name}" (position ${String(index + 1)}).`,
+      );
+    }
+  }
+
+  return out;
+}
+
+export async function runChatbot(options: RunChatbotOptions): Promise<void> {
+  const output = options.output ?? console.log;
+  const outputChunk = options.outputChunk ?? ((text) => process.stdout.write(text));
+  const stream = options.stream ?? true;
+
+  while (true) {
+    let userInput: string;
+
+    try {
+      userInput = await options.input('> ');
+    } catch {
+      output('');
+
+      return;
+    }
+
+    const trimmed = userInput.trim();
+
+    if (trimmed === '') {
+      continue;
+    }
+
+    if (trimmed === 'exit' || trimmed === 'quit') {
+      return;
+    }
+
+    if (trimmed === '/') {
+      const commands = await listAvailableCommands(options.documentServer);
+      output(
+        commands.length === 0
+          ? '(no MCP commands available)'
+          : `Commands: /${commands.join(', /')}`,
+      );
+      continue;
+    }
+
+    if (trimmed === '@') {
+      const docs = await listKnownDocumentIds(options.documentServer);
+      output(docs.length === 0 ? '(no documents available)' : `Documents: @${docs.join(', @')}`);
+      continue;
+    }
+
+    const parsedCommand = parseSlashCommand(trimmed);
+    let streamedTextNeedsLineBreak = false;
+
+    const outputLine = (line: string): void => {
+      if (streamedTextNeedsLineBreak) {
+        output('');
+        streamedTextNeedsLineBreak = false;
+      }
+
+      output(line);
+    };
+
+    const chatOptions: ChatOptions = {
+      stream,
+      ...(options.maxTokens === undefined ? {} : { maxTokens: options.maxTokens }),
+      onToolEvent: (event) => {
+        const line = formatToolEvent(event);
+
+        if (line !== undefined) {
+          outputLine(line);
+        }
+      },
+    };
+    let didStreamText = false;
+
+    chatOptions.onTextDelta = (text) => {
+      didStreamText = true;
+      streamedTextNeedsLineBreak = text.length > 0 && !text.endsWith('\n');
+      outputChunk(text);
+    };
+
+    let messageText: string;
+
+    if (parsedCommand === undefined) {
+      const mentions = await resolveMentions(options.documentServer, userInput);
+
+      for (const docId of mentions.unknown) {
+        output(`[context] Unknown document: @${docId}`);
+      }
+
+      messageText = buildUserTextWithContext(userInput, mentions.snippets);
+    } else {
+      const prompts = await options.documentServer.listPrompts();
+      const promptMeta = prompts.find((p) => p.name === parsedCommand.name);
+
+      if (promptMeta === undefined) {
+        output(`Unknown command: /${parsedCommand.name}`);
+        continue;
+      }
+
+      let promptArgs: Record<string, string>;
+
+      try {
+        promptArgs = buildPromptArgsRecord(
+          parsedCommand.name,
+          parsedCommand.args,
+          promptMeta.arguments,
+        );
+      } catch (error) {
+        output(error instanceof Error ? error.message : String(error));
+        continue;
+      }
+
+      const promptResult = await options.documentServer.getPrompt(parsedCommand.name, promptArgs);
+      const promptMessages = mcpPromptToChatMessages(promptResult);
+
+      if (promptMessages.length === 0) {
+        output('(prompt returned no text messages)');
+        continue;
+      }
+
+      const head = promptMessages.slice(0, -1);
+      const lastMessage = promptMessages.at(-1);
+
+      if (lastMessage?.role !== 'user') {
+        options.session.appendMessages(promptMessages);
+        const answer = await options.session.sendUserMessage(
+          '(continue with the instructions above)',
+          chatOptions,
+        );
+        output(didStreamText ? '' : answer);
+        continue;
+      }
+
+      options.session.appendMessages(head);
+
+      if (typeof lastMessage.content === 'string') {
+        messageText = lastMessage.content;
+      } else {
+        output('(prompt last message had non-text content; skipping turn)');
+        continue;
+      }
+    }
+
+    const answer = await options.session.sendUserMessage(messageText, chatOptions);
+    output(didStreamText ? '' : answer);
+  }
+}

--- a/workspaces/ai-engineering/mcp-chat/src/client/mcp-client.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/client/mcp-client.ts
@@ -1,0 +1,121 @@
+import {
+  Client,
+  StdioClientTransport,
+  type StdioServerParameters,
+} from '@modelcontextprotocol/client';
+
+export const CLIENT_NAME = 'mcp-chat-client';
+export const CLIENT_VERSION = '0.1.0';
+
+export type McpTool = Awaited<ReturnType<Client['listTools']>>['tools'][number];
+export type McpResource = Awaited<ReturnType<Client['listResources']>>['resources'][number];
+export type McpResourceTemplate = Awaited<
+  ReturnType<Client['listResourceTemplates']>
+>['resourceTemplates'][number];
+export type McpPrompt = Awaited<ReturnType<Client['listPrompts']>>['prompts'][number];
+export type McpCallToolResult = Awaited<ReturnType<Client['callTool']>>;
+export type McpReadResourceResult = Awaited<ReturnType<Client['readResource']>>;
+export type McpGetPromptResult = Awaited<ReturnType<Client['getPrompt']>>;
+
+export interface McpStdioClient {
+  callTool(name: string, args: Record<string, unknown>): Promise<McpCallToolResult>;
+  close(): Promise<void>;
+  getPrompt(name: string, args?: Record<string, string>): Promise<McpGetPromptResult>;
+  listPrompts(): Promise<readonly McpPrompt[]>;
+  listResources(): Promise<readonly McpResource[]>;
+  listResourceTemplates(): Promise<readonly McpResourceTemplate[]>;
+  listTools(): Promise<readonly McpTool[]>;
+  readResource(uri: string): Promise<McpReadResourceResult>;
+}
+
+export interface ConnectMcpStdioClientOptions {
+  readonly clientName?: string;
+  readonly clientVersion?: string;
+  readonly server: StdioServerParameters;
+}
+
+async function paginate<T>(
+  fetchPage: (
+    cursor: string | undefined,
+  ) => Promise<{ items: readonly T[]; nextCursor: string | undefined }>,
+): Promise<readonly T[]> {
+  const collected: T[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const page = await fetchPage(cursor);
+    collected.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor !== undefined && cursor !== '');
+
+  return collected;
+}
+
+export async function connectMcpStdioClient(
+  options: ConnectMcpStdioClientOptions,
+): Promise<McpStdioClient> {
+  const client = new Client({
+    name: options.clientName ?? CLIENT_NAME,
+    version: options.clientVersion ?? CLIENT_VERSION,
+  });
+  const transport = new StdioClientTransport(options.server);
+
+  await client.connect(transport);
+
+  return {
+    async callTool(name, args) {
+      return client.callTool({ arguments: args, name });
+    },
+    async close() {
+      try {
+        await client.close();
+      } catch (error) {
+        console.error('[mcp-client] error closing client:', error);
+      }
+
+      try {
+        await transport.close();
+      } catch (error) {
+        console.error('[mcp-client] error closing transport:', error);
+      }
+    },
+    async getPrompt(name, args) {
+      return client.getPrompt({ arguments: args ?? {}, name });
+    },
+    async listPrompts() {
+      return paginate<McpPrompt>(async (cursor) => {
+        const params = cursor === undefined ? undefined : { cursor };
+        const page = await client.listPrompts(params);
+
+        return { items: page.prompts, nextCursor: page.nextCursor };
+      });
+    },
+    async listResources() {
+      return paginate<McpResource>(async (cursor) => {
+        const params = cursor === undefined ? undefined : { cursor };
+        const page = await client.listResources(params);
+
+        return { items: page.resources, nextCursor: page.nextCursor };
+      });
+    },
+    async listResourceTemplates() {
+      return paginate<McpResourceTemplate>(async (cursor) => {
+        const params = cursor === undefined ? undefined : { cursor };
+        const page = await client.listResourceTemplates(params);
+
+        return { items: page.resourceTemplates, nextCursor: page.nextCursor };
+      });
+    },
+    async listTools() {
+      return paginate<McpTool>(async (cursor) => {
+        const params = cursor === undefined ? undefined : { cursor };
+        const page = await client.listTools(params);
+
+        return { items: page.tools, nextCursor: page.nextCursor };
+      });
+    },
+    async readResource(uri) {
+      return client.readResource({ uri });
+    },
+  };
+}

--- a/workspaces/ai-engineering/mcp-chat/src/documents/document-store.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/documents/document-store.ts
@@ -1,0 +1,105 @@
+export class DocumentNotFoundError extends Error {
+  readonly code = 'document_not_found';
+
+  constructor(public readonly docId: string) {
+    super(`Document not found: ${docId}`);
+    this.name = 'DocumentNotFoundError';
+  }
+}
+
+export class DocumentEditError extends Error {
+  readonly code: 'empty_old_str' | 'old_str_not_found' | 'old_str_not_unique';
+
+  constructor(code: 'empty_old_str' | 'old_str_not_found' | 'old_str_not_unique', message: string) {
+    super(message);
+    this.code = code;
+    this.name = 'DocumentEditError';
+  }
+}
+
+export interface EditDocumentParams {
+  readonly docId: string;
+  readonly newStr: string;
+  readonly oldStr: string;
+}
+
+export interface EditDocumentResult {
+  readonly docId: string;
+  readonly replacements: number;
+}
+
+export interface DocumentStore {
+  editDocument(params: EditDocumentParams): EditDocumentResult;
+  listDocumentIds(): readonly string[];
+  readDocument(docId: string): string;
+}
+
+function countOccurrences(text: string, needle: string): number {
+  if (needle === '') {
+    return 0;
+  }
+
+  let count = 0;
+  let index = text.indexOf(needle);
+
+  while (index !== -1) {
+    count += 1;
+    index = text.indexOf(needle, index + needle.length);
+  }
+
+  return count;
+}
+
+export function createDocumentStore(seed: Readonly<Record<string, string>>): DocumentStore {
+  const documents = new Map<string, string>(Object.entries(seed));
+
+  return {
+    editDocument({ docId, newStr, oldStr }) {
+      const content = documents.get(docId);
+
+      if (content === undefined) {
+        throw new DocumentNotFoundError(docId);
+      }
+
+      if (oldStr === '') {
+        throw new DocumentEditError(
+          'empty_old_str',
+          'old_str must not be empty. Provide the exact text to replace.',
+        );
+      }
+
+      const matches = countOccurrences(content, oldStr);
+
+      if (matches === 0) {
+        throw new DocumentEditError(
+          'old_str_not_found',
+          `old_str was not found in document "${docId}". Provide an exact substring.`,
+        );
+      }
+
+      if (matches > 1) {
+        throw new DocumentEditError(
+          'old_str_not_unique',
+          `old_str matched ${String(matches)} times in document "${docId}". Provide a longer substring that uniquely identifies the location.`,
+        );
+      }
+
+      const updated = content.replace(oldStr, newStr);
+      documents.set(docId, updated);
+
+      return { docId, replacements: 1 };
+    },
+    listDocumentIds() {
+      return [...documents.keys()].toSorted();
+    },
+    readDocument(docId) {
+      const content = documents.get(docId);
+
+      if (content === undefined) {
+        throw new DocumentNotFoundError(docId);
+      }
+
+      return content;
+    },
+  };
+}

--- a/workspaces/ai-engineering/mcp-chat/src/documents/seed-documents.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/documents/seed-documents.ts
@@ -1,0 +1,14 @@
+export const SEED_DOCUMENTS: Readonly<Record<string, string>> = Object.freeze({
+  'deposition.md':
+    '# Deposition Notes\n\nWitness: Jane Doe.\nDate: 2026-04-12.\nSummary: The witness stated that she observed the delivery truck enter the loading dock at 09:14.\nFollow-up: Confirm the timestamp on the dock camera footage and cross-reference with the visitor log.',
+  'financials.docx':
+    '# Q1 Financial Summary\n\nRevenue: $4.8M (+12% YoY).\nGross margin: 61%.\nOperating expenses: $2.1M.\nNotes: Marketing spend exceeded plan by $180k due to the spring campaign extension.',
+  'outlook.pdf':
+    '# Forward-Looking Outlook\n\nWe expect modest growth in the second half of 2026 driven by enterprise renewals.\nDownside risk: hiring delays in the platform team push the launch of feature X to Q1 2027.',
+  'plan.md':
+    '# Project Plan\n\n## Milestones\n\n- Milestone A: scope locked by 2026-05-15.\n- Milestone B: prototype demo on 2026-06-01.\n- Milestone C: GA candidate by 2026-08-15.\n\n## Owners\n\n- Platform: A. Engineer.\n- Product: B. Owner.',
+  'report.pdf':
+    '# Quarterly Report\n\n## Highlights\n\n- Shipped two major features.\n- Reduced p95 latency on the search endpoint from 480ms to 210ms.\n\n## Concerns\n\n- Onboarding completion rate is flat versus last quarter.',
+  'spec.txt':
+    'Specification: document-mcp-server\n--------------------------------\nThe server exposes read_doc_contents and edit_document tools backed by an in-memory store.\nResources: docs://documents and docs://documents/{doc_id}.\nPrompts: format.',
+});

--- a/workspaces/ai-engineering/mcp-chat/src/server/document-mcp-server.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/server/document-mcp-server.ts
@@ -1,0 +1,294 @@
+import {
+  CfWorkerJsonSchemaValidator,
+  fromJsonSchema,
+  McpServer,
+  ResourceTemplate,
+} from '@modelcontextprotocol/server';
+
+import {
+  DocumentEditError,
+  DocumentNotFoundError,
+  type DocumentStore,
+} from '../documents/document-store.js';
+
+export const SERVER_NAME = 'document-mcp-server';
+export const SERVER_VERSION = '0.1.0';
+
+export const DOCUMENTS_LIST_URI = 'docs://documents';
+const DOCUMENT_RESOURCE_PREFIX = 'docs://documents/';
+const DOCUMENT_TEMPLATE = 'docs://documents/{doc_id}';
+
+interface ReadDocArgs {
+  readonly doc_id: string;
+}
+
+interface EditDocArgs {
+  readonly doc_id: string;
+  readonly new_str: string;
+  readonly old_str: string;
+}
+
+interface FormatPromptArgs {
+  readonly doc_id: string;
+}
+
+const validator = new CfWorkerJsonSchemaValidator({ draft: '2020-12' });
+
+const readDocInputSchema = fromJsonSchema<ReadDocArgs>(
+  {
+    additionalProperties: false,
+    properties: {
+      doc_id: { description: 'Identifier of the document to read.', minLength: 1, type: 'string' },
+    },
+    required: ['doc_id'],
+    type: 'object',
+  },
+  validator,
+);
+
+const readDocOutputSchema = fromJsonSchema<{ content: string; doc_id: string }>(
+  {
+    additionalProperties: false,
+    properties: {
+      content: { type: 'string' },
+      doc_id: { type: 'string' },
+    },
+    required: ['content', 'doc_id'],
+    type: 'object',
+  },
+  validator,
+);
+
+const editDocInputSchema = fromJsonSchema<EditDocArgs>(
+  {
+    additionalProperties: false,
+    properties: {
+      doc_id: { description: 'Identifier of the document to edit.', minLength: 1, type: 'string' },
+      new_str: { description: 'Replacement text. May be empty to delete old_str.', type: 'string' },
+      old_str: {
+        description: 'Exact substring to replace. Must appear once.',
+        minLength: 1,
+        type: 'string',
+      },
+    },
+    required: ['doc_id', 'old_str', 'new_str'],
+    type: 'object',
+  },
+  validator,
+);
+
+const editDocOutputSchema = fromJsonSchema<{
+  doc_id: string;
+  replacements: number;
+  updated: boolean;
+}>(
+  {
+    additionalProperties: false,
+    properties: {
+      doc_id: { type: 'string' },
+      replacements: { minimum: 0, type: 'integer' },
+      updated: { type: 'boolean' },
+    },
+    required: ['doc_id', 'replacements', 'updated'],
+    type: 'object',
+  },
+  validator,
+);
+
+const formatPromptArgsSchema = fromJsonSchema<FormatPromptArgs>(
+  {
+    additionalProperties: false,
+    properties: {
+      doc_id: { description: 'Document id to format.', minLength: 1, type: 'string' },
+    },
+    required: ['doc_id'],
+    type: 'object',
+  },
+  validator,
+);
+
+function isErrorWithMessage(error: unknown): error is { message: string } {
+  return typeof error === 'object' && error !== null && 'message' in error;
+}
+
+function errorMessage(error: unknown): string {
+  return isErrorWithMessage(error) ? error.message : String(error);
+}
+
+export function createDocumentMcpServer(store: DocumentStore): McpServer {
+  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+
+  server.registerTool(
+    'read_doc_contents',
+    {
+      description: 'Read the full text contents of a document by its id.',
+      inputSchema: readDocInputSchema,
+      outputSchema: readDocOutputSchema,
+      title: 'Read document contents',
+    },
+    (args) => {
+      const { doc_id } = args;
+
+      try {
+        const content = store.readDocument(doc_id);
+        const structured = { content, doc_id };
+
+        return {
+          content: [{ text: content, type: 'text' as const }],
+          structuredContent: structured,
+        };
+      } catch (error) {
+        if (error instanceof DocumentNotFoundError) {
+          return {
+            content: [{ text: `Document "${doc_id}" was not found.`, type: 'text' as const }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [
+            { text: `Failed to read document: ${errorMessage(error)}`, type: 'text' as const },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    'edit_document',
+    {
+      description:
+        'Edit a document by replacing an exact substring. old_str must match exactly once.',
+      inputSchema: editDocInputSchema,
+      outputSchema: editDocOutputSchema,
+      title: 'Edit document',
+    },
+    (args) => {
+      const { doc_id, new_str, old_str } = args;
+
+      try {
+        const result = store.editDocument({ docId: doc_id, newStr: new_str, oldStr: old_str });
+        const structured = {
+          doc_id: result.docId,
+          replacements: result.replacements,
+          updated: result.replacements > 0,
+        };
+
+        return {
+          content: [
+            {
+              text: `Updated "${result.docId}" (${String(result.replacements)} replacement).`,
+              type: 'text' as const,
+            },
+          ],
+          structuredContent: structured,
+        };
+      } catch (error) {
+        if (error instanceof DocumentNotFoundError || error instanceof DocumentEditError) {
+          return {
+            content: [{ text: error.message, type: 'text' as const }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [
+            { text: `Failed to edit document: ${errorMessage(error)}`, type: 'text' as const },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerResource(
+    'documents-list',
+    DOCUMENTS_LIST_URI,
+    {
+      description: 'JSON array of all document ids known to the server.',
+      mimeType: 'application/json',
+      title: 'All documents',
+    },
+    (uri) => ({
+      contents: [
+        {
+          mimeType: 'application/json',
+          text: JSON.stringify({ documents: store.listDocumentIds() }),
+          uri: uri.href,
+        },
+      ],
+    }),
+  );
+
+  server.registerResource(
+    'document',
+    new ResourceTemplate(DOCUMENT_TEMPLATE, {
+      list: () => ({
+        resources: store.listDocumentIds().map((docId) => ({
+          mimeType: 'text/plain',
+          name: docId,
+          title: docId,
+          uri: `${DOCUMENT_RESOURCE_PREFIX}${docId}`,
+        })),
+      }),
+    }),
+    {
+      description: 'Plain-text contents of an individual document.',
+      mimeType: 'text/plain',
+      title: 'Document content',
+    },
+    (uri, variables) => {
+      const docIdRaw = variables.doc_id;
+      const docId = Array.isArray(docIdRaw) ? docIdRaw[0] : docIdRaw;
+
+      if (typeof docId !== 'string' || docId === '') {
+        throw new Error('doc_id is required in the resource URI.');
+      }
+
+      return {
+        contents: [
+          {
+            mimeType: 'text/plain',
+            text: store.readDocument(docId),
+            uri: uri.href,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerPrompt(
+    'format',
+    {
+      argsSchema: formatPromptArgsSchema,
+      description:
+        'Read the document and improve formatting using edit_document when changes are warranted.',
+      title: 'Format document',
+    },
+    (args) => {
+      const { doc_id } = args;
+
+      return {
+        messages: [
+          {
+            content: {
+              text: [
+                `You are formatting the document "${doc_id}".`,
+                '',
+                '1. Call the read_doc_contents tool to retrieve the current text.',
+                '2. Identify formatting issues: inconsistent headings, broken markdown, trailing whitespace, or unwrapped paragraphs.',
+                '3. When changes are warranted, call edit_document with a unique old_str and a corrected new_str. Make one targeted edit at a time.',
+                '4. When no further changes are needed, summarize what you changed and why in plain text.',
+              ].join('\n'),
+              type: 'text' as const,
+            },
+            role: 'user' as const,
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}

--- a/workspaces/ai-engineering/mcp-chat/src/server/main.ts
+++ b/workspaces/ai-engineering/mcp-chat/src/server/main.ts
@@ -1,0 +1,41 @@
+import { StdioServerTransport } from '@modelcontextprotocol/server';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createDocumentStore } from '../documents/document-store.js';
+import { SEED_DOCUMENTS } from '../documents/seed-documents.js';
+import { createDocumentMcpServer } from './document-mcp-server.js';
+
+async function main(): Promise<void> {
+  const store = createDocumentStore(SEED_DOCUMENTS);
+  const server = createDocumentMcpServer(store);
+  const transport = new StdioServerTransport();
+
+  let shuttingDown = false;
+
+  const shutdown = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    console.error(`[document-mcp-server] received ${signal}, shutting down`);
+    server.close().catch((error: unknown) => {
+      console.error('[document-mcp-server] shutdown error:', error);
+      process.exitCode = 1;
+    });
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  await server.connect(transport);
+}
+
+export function isDirectExecution(moduleUrl: string, entrypointPath: string | undefined): boolean {
+  return entrypointPath !== undefined && fileURLToPath(moduleUrl) === path.resolve(entrypointPath);
+}
+
+if (isDirectExecution(import.meta.url, process.argv[1])) {
+  await main();
+}

--- a/workspaces/ai-engineering/mcp-chat/tests/chat/chat-session.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/chat/chat-session.test.ts
@@ -1,0 +1,176 @@
+import type {
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmToolResultBlock,
+  LlmToolUseBlock,
+} from '@workspaces/packages/llm-client';
+import { describe, expect, it } from 'vitest';
+
+import { createChatSession } from '../../src/chat/chat-session.js';
+import type { McpToolManager } from '../../src/chat/mcp-tool-manager.js';
+
+function fakeProvider(responses: readonly LlmResponse[]): {
+  calls: LlmRequest[];
+  provider: LlmProvider;
+} {
+  const calls: LlmRequest[] = [];
+  const remaining = [...responses];
+  const provider: LlmProvider = {
+    createMessage: (request) => {
+      calls.push(request);
+      const response = remaining.shift();
+
+      if (response === undefined) {
+        throw new Error('No fake response configured');
+      }
+
+      return Promise.resolve(response);
+    },
+  };
+
+  return { calls, provider };
+}
+
+function fakeToolManager(toolResults: Map<string, LlmToolResultBlock>): {
+  invocations: LlmToolUseBlock[];
+  manager: McpToolManager;
+} {
+  const invocations: LlmToolUseBlock[] = [];
+  const manager: McpToolManager = {
+    callTool: (toolUse) => {
+      invocations.push(toolUse);
+      const result = toolResults.get(toolUse.name);
+
+      if (result === undefined) {
+        return Promise.resolve({
+          content: `no result for ${toolUse.name}`,
+          is_error: true,
+          tool_use_id: toolUse.id,
+          type: 'tool_result',
+        });
+      }
+
+      return Promise.resolve({ ...result, tool_use_id: toolUse.id });
+    },
+    clients: [],
+    toolDefinitions: () => [
+      {
+        description: 'fake tool',
+        inputSchema: { type: 'object' },
+        name: 'do_thing',
+      },
+    ],
+  };
+
+  return { invocations, manager };
+}
+
+describe('chat session', () => {
+  it('appends user and assistant turns and returns assistant text', async () => {
+    const { calls, provider } = fakeProvider([{ raw: {}, stopReason: 'end_turn', text: 'Hi' }]);
+    const { manager } = fakeToolManager(new Map());
+    const session = createChatSession({ model: 'm', provider, toolManager: manager });
+
+    const answer = await session.sendUserMessage('Hello');
+
+    expect(answer).toBe('Hi');
+    expect(session.history).toEqual([
+      { content: 'Hello', role: 'user' },
+      { content: [{ text: 'Hi', type: 'text' }], role: 'assistant' },
+    ]);
+    expect(calls[0]?.tools?.length).toBe(1);
+  });
+
+  it('runs MCP tools and submits tool_result blocks in the right order', async () => {
+    const toolUseBlock: LlmToolUseBlock = {
+      id: 'use-1',
+      input: { x: 1 },
+      name: 'do_thing',
+      type: 'tool_use',
+    };
+    const { provider } = fakeProvider([
+      {
+        content: [toolUseBlock],
+        raw: {},
+        stopReason: 'tool_use',
+        text: '',
+      },
+      { raw: {}, stopReason: 'end_turn', text: 'Done.' },
+    ]);
+    const results = new Map<string, LlmToolResultBlock>([
+      ['do_thing', { content: 'tool reply', tool_use_id: 'placeholder', type: 'tool_result' }],
+    ]);
+    const { invocations, manager } = fakeToolManager(results);
+    const session = createChatSession({ model: 'm', provider, toolManager: manager });
+
+    const answer = await session.sendUserMessage('please');
+
+    expect(answer).toBe('Done.');
+    expect(invocations).toHaveLength(1);
+
+    const assistantToolUseTurn = session.history[1];
+    const userToolResultTurn = session.history[2];
+    const finalAssistantTurn = session.history[3];
+
+    expect(assistantToolUseTurn?.role).toBe('assistant');
+    expect(userToolResultTurn?.role).toBe('user');
+    expect(userToolResultTurn?.content).toEqual([
+      { content: 'tool reply', tool_use_id: 'use-1', type: 'tool_result' },
+    ]);
+    expect(finalAssistantTurn?.role).toBe('assistant');
+  });
+
+  it('throws when tool rounds exceed the maximum', async () => {
+    const toolUseBlock: LlmToolUseBlock = {
+      id: 'use-1',
+      input: {},
+      name: 'do_thing',
+      type: 'tool_use',
+    };
+    const { provider } = fakeProvider([
+      { content: [toolUseBlock], raw: {}, stopReason: 'tool_use', text: '' },
+      { content: [toolUseBlock], raw: {}, stopReason: 'tool_use', text: '' },
+    ]);
+    const results = new Map<string, LlmToolResultBlock>([
+      ['do_thing', { content: 'ok', tool_use_id: 'placeholder', type: 'tool_result' }],
+    ]);
+    const { manager } = fakeToolManager(results);
+    const session = createChatSession({ model: 'm', provider, toolManager: manager });
+
+    await expect(session.sendUserMessage('go', { maxToolRounds: 1 })).rejects.toThrow(
+      /maximum round limit/,
+    );
+  });
+
+  it('continues after pause_turn responses before returning final text', async () => {
+    const { provider } = fakeProvider([
+      { raw: {}, stopReason: 'pause_turn', text: 'Partial.' },
+      { raw: {}, stopReason: 'end_turn', text: 'Done.' },
+    ]);
+    const { manager } = fakeToolManager(new Map());
+    const session = createChatSession({ model: 'm', provider, toolManager: manager });
+
+    const answer = await session.sendUserMessage('continue');
+
+    expect(answer).toBe('Done.');
+    expect(session.history).toEqual([
+      { content: 'continue', role: 'user' },
+      { content: [{ text: 'Partial.', type: 'text' }], role: 'assistant' },
+      { content: [{ text: 'Done.', type: 'text' }], role: 'assistant' },
+    ]);
+  });
+
+  it('throws when pause_turn continuation exceeds the maximum', async () => {
+    const responses = Array.from({ length: 6 }, () => ({
+      raw: {},
+      stopReason: 'pause_turn',
+      text: 'Partial.',
+    }));
+    const { provider } = fakeProvider(responses);
+    const { manager } = fakeToolManager(new Map());
+    const session = createChatSession({ model: 'm', provider, toolManager: manager });
+
+    await expect(session.sendUserMessage('continue')).rejects.toThrow(/pause_turn/);
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/chat/document-context.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/chat/document-context.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildUserTextWithContext,
+  extractDocumentMentions,
+  listKnownDocumentIds,
+  resolveMentions,
+} from '../../src/chat/document-context.js';
+import type { McpStdioClient } from '../../src/client/mcp-client.js';
+
+function fakeClient(documents: Record<string, string>): McpStdioClient {
+  return {
+    callTool: () =>
+      Promise.resolve({ content: [] } as unknown as Awaited<
+        ReturnType<McpStdioClient['callTool']>
+      >),
+    close: () => Promise.resolve(),
+    getPrompt: () =>
+      Promise.resolve({ messages: [] } as unknown as Awaited<
+        ReturnType<McpStdioClient['getPrompt']>
+      >),
+    listPrompts: () => Promise.resolve([]),
+    listResources: () => Promise.resolve([]),
+    listResourceTemplates: () => Promise.resolve([]),
+    listTools: () => Promise.resolve([]),
+    readResource: (uri: string) => {
+      if (uri === 'docs://documents') {
+        return Promise.resolve({
+          contents: [
+            {
+              mimeType: 'application/json',
+              text: JSON.stringify({ documents: Object.keys(documents) }),
+              uri,
+            },
+          ],
+        } as unknown as Awaited<ReturnType<McpStdioClient['readResource']>>);
+      }
+
+      const docId = uri.replace('docs://documents/', '');
+      const text = documents[docId];
+
+      if (text === undefined) {
+        return Promise.reject(new Error(`Unknown document: ${docId}`));
+      }
+
+      return Promise.resolve({
+        contents: [{ mimeType: 'text/plain', text, uri }],
+      } as unknown as Awaited<ReturnType<McpStdioClient['readResource']>>);
+    },
+  };
+}
+
+describe('document context', () => {
+  it('extracts unique document mentions preserving order', () => {
+    expect(extractDocumentMentions('see @a.md and @b.md plus @a.md again')).toEqual([
+      'a.md',
+      'b.md',
+    ]);
+  });
+
+  it('ignores sentence-final periods after document mentions', () => {
+    expect(extractDocumentMentions('please compare @a.md. Then read @b.md...')).toEqual([
+      'a.md',
+      'b.md',
+    ]);
+  });
+
+  it('ignores text without mentions', () => {
+    expect(extractDocumentMentions('no mentions here')).toEqual([]);
+  });
+
+  it('lists known document ids from the resource', async () => {
+    const client = fakeClient({ 'a.md': '1', 'b.md': '2' });
+
+    expect(await listKnownDocumentIds(client)).toEqual(['a.md', 'b.md']);
+  });
+
+  it('returns matching snippets and unknown ids', async () => {
+    const client = fakeClient({ 'a.md': 'alpha', 'b.md': 'beta' });
+    const result = await resolveMentions(client, 'compare @a.md and @missing.md');
+
+    expect(result.snippets).toEqual([{ content: 'alpha', docId: 'a.md' }]);
+    expect(result.unknown).toEqual(['missing.md']);
+  });
+
+  it('resolves document mentions followed by sentence punctuation', async () => {
+    const client = fakeClient({ 'a.md': 'alpha' });
+    const result = await resolveMentions(client, 'summarize @a.md.');
+
+    expect(result.snippets).toEqual([{ content: 'alpha', docId: 'a.md' }]);
+    expect(result.unknown).toEqual([]);
+  });
+
+  it('returns empty result when no mentions present', async () => {
+    const client = fakeClient({ 'a.md': 'alpha' });
+    const result = await resolveMentions(client, 'no mentions');
+
+    expect(result.snippets).toEqual([]);
+    expect(result.unknown).toEqual([]);
+  });
+
+  it('builds user text with referenced documents inline', () => {
+    const text = buildUserTextWithContext('please summarize', [
+      { content: 'alpha\nbeta', docId: 'a.md' },
+    ]);
+
+    expect(text).toContain('<document id="a.md">');
+    expect(text).toContain('alpha\nbeta');
+    expect(text).toContain('User message:\nplease summarize');
+  });
+
+  it('returns the bare user text when there are no snippets', () => {
+    expect(buildUserTextWithContext('hello', [])).toBe('hello');
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/chat/mcp-tool-manager.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/chat/mcp-tool-manager.test.ts
@@ -1,0 +1,153 @@
+import type { LlmToolUseBlock } from '@workspaces/packages/llm-client';
+import { describe, expect, it } from 'vitest';
+
+import { createMcpToolManager } from '../../src/chat/mcp-tool-manager.js';
+import type { McpCallToolResult, McpStdioClient, McpTool } from '../../src/client/mcp-client.js';
+
+function fakeTool(name: string, description: string): McpTool {
+  return {
+    description,
+    inputSchema: {
+      properties: { value: { type: 'string' } },
+      required: ['value'],
+      type: 'object',
+    },
+    name,
+  };
+}
+
+function fakeClient(
+  name: string,
+  tools: readonly McpTool[],
+  callResult: (toolName: string, args: Record<string, unknown>) => McpCallToolResult,
+): { calls: { args: Record<string, unknown>; name: string }[]; client: McpStdioClient } {
+  const calls: { args: Record<string, unknown>; name: string }[] = [];
+  void name;
+
+  const client: McpStdioClient = {
+    callTool: (toolName, args) => {
+      calls.push({ args, name: toolName });
+
+      return Promise.resolve(callResult(toolName, args));
+    },
+    close: () => Promise.resolve(),
+    getPrompt: () =>
+      Promise.resolve({ messages: [] } as unknown as Awaited<
+        ReturnType<McpStdioClient['getPrompt']>
+      >),
+    listPrompts: () => Promise.resolve([]),
+    listResources: () => Promise.resolve([]),
+    listResourceTemplates: () => Promise.resolve([]),
+    listTools: () => Promise.resolve(tools),
+    readResource: () =>
+      Promise.resolve({
+        contents: [],
+      } as unknown as Awaited<ReturnType<McpStdioClient['readResource']>>),
+  };
+
+  return { calls, client };
+}
+
+describe('mcp tool manager', () => {
+  it('converts MCP tools to LLM tool definitions', async () => {
+    const { client } = fakeClient('docs', [fakeTool('greet', 'Say hi')], () => ({
+      content: [{ text: 'ok', type: 'text' }],
+    }));
+
+    const manager = await createMcpToolManager({ clients: [{ client, name: 'docs' }] });
+    const defs = manager.toolDefinitions();
+
+    expect(defs).toEqual([
+      {
+        description: 'Say hi',
+        inputSchema: {
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          type: 'object',
+        },
+        name: 'greet',
+      },
+    ]);
+  });
+
+  it('routes tool calls to the owning client and returns text content', async () => {
+    const { calls, client } = fakeClient('docs', [fakeTool('greet', 'Say hi')], (name, args) => ({
+      content: [{ text: `hi ${String(args.value)}`, type: 'text' }],
+      structuredContent: { received: name },
+    }));
+
+    const manager = await createMcpToolManager({ clients: [{ client, name: 'docs' }] });
+    const toolUse: LlmToolUseBlock = {
+      id: 'use-1',
+      input: { value: 'there' },
+      name: 'greet',
+      type: 'tool_use',
+    };
+
+    const result = await manager.callTool(toolUse);
+
+    expect(result).toEqual({
+      content: 'hi there',
+      tool_use_id: 'use-1',
+      type: 'tool_result',
+    });
+    expect(calls).toEqual([{ args: { value: 'there' }, name: 'greet' }]);
+  });
+
+  it('preserves is_error when MCP reports an error', async () => {
+    const { client } = fakeClient('docs', [fakeTool('greet', 'Say hi')], () => ({
+      content: [{ text: 'boom', type: 'text' }],
+      isError: true,
+    }));
+
+    const manager = await createMcpToolManager({ clients: [{ client, name: 'docs' }] });
+    const toolUse: LlmToolUseBlock = {
+      id: 'use-2',
+      input: { value: 'x' },
+      name: 'greet',
+      type: 'tool_use',
+    };
+
+    const result = await manager.callTool(toolUse);
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toBe('boom');
+  });
+
+  it('returns is_error=true for an unknown tool', async () => {
+    const { client } = fakeClient('docs', [fakeTool('greet', 'Say hi')], () => ({
+      content: [{ text: 'ok', type: 'text' }],
+    }));
+
+    const manager = await createMcpToolManager({ clients: [{ client, name: 'docs' }] });
+    const toolUse: LlmToolUseBlock = {
+      id: 'use-3',
+      input: {},
+      name: 'unknown',
+      type: 'tool_use',
+    };
+
+    const result = await manager.callTool(toolUse);
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain('Unknown MCP tool');
+  });
+
+  it('rejects duplicate tool names across clients', async () => {
+    const a = fakeClient('a', [fakeTool('shared', 'A')], () => ({
+      content: [{ text: 'a', type: 'text' }],
+    }));
+    const b = fakeClient('b', [fakeTool('shared', 'B')], () => ({
+      content: [{ text: 'b', type: 'text' }],
+    }));
+
+    await expect(
+      createMcpToolManager({
+        clients: [
+          { client: a.client, name: 'a' },
+          { client: b.client, name: 'b' },
+        ],
+      }),
+    ).rejects.toThrow(/registered by more than one server/);
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/chat/prompt-converter.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/chat/prompt-converter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { mcpPromptToChatMessages } from '../../src/chat/prompt-converter.js';
+import type { McpGetPromptResult } from '../../src/client/mcp-client.js';
+
+function textPrompt(role: 'user' | 'assistant', text: string): McpGetPromptResult['messages'][0] {
+  return {
+    content: { text, type: 'text' },
+    role,
+  };
+}
+
+describe('prompt converter', () => {
+  it('converts text prompt messages to ChatMessage values', () => {
+    const result = {
+      messages: [textPrompt('user', 'hello'), textPrompt('assistant', 'hi')],
+    } as unknown as McpGetPromptResult;
+
+    expect(mcpPromptToChatMessages(result)).toEqual([
+      { content: 'hello', role: 'user' },
+      { content: 'hi', role: 'assistant' },
+    ]);
+  });
+
+  it('skips non-text prompt content', () => {
+    const result = {
+      messages: [
+        textPrompt('user', 'first'),
+        {
+          content: { data: 'AA==', mimeType: 'image/png', type: 'image' },
+          role: 'user',
+        },
+      ],
+    } as unknown as McpGetPromptResult;
+
+    expect(mcpPromptToChatMessages(result)).toEqual([{ content: 'first', role: 'user' }]);
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/cli/args.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/cli/args.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseArgs } from '../../src/cli/args.js';
+
+describe('parseArgs', () => {
+  it('defaults to streaming on and dist server', () => {
+    expect(parseArgs([])).toEqual({
+      shouldPrintHelp: false,
+      stream: true,
+      useDevServer: false,
+    });
+  });
+
+  it('parses --no-stream', () => {
+    expect(parseArgs(['--no-stream']).stream).toBe(false);
+  });
+
+  it('parses --server-dev', () => {
+    expect(parseArgs(['--server-dev']).useDevServer).toBe(true);
+  });
+
+  it('parses --max-tokens with a numeric argument', () => {
+    expect(parseArgs(['--max-tokens', '256']).maxTokens).toBe(256);
+  });
+
+  it('throws for --max-tokens without a value', () => {
+    expect(() => parseArgs(['--max-tokens'])).toThrow(/requires a numeric argument/);
+  });
+
+  it('throws for non-positive --max-tokens values', () => {
+    expect(() => parseArgs(['--max-tokens', '0'])).toThrow(/positive integer/);
+  });
+
+  it('throws for partial --max-tokens values', () => {
+    expect(() => parseArgs(['--max-tokens', '1.5'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--max-tokens', '12abc'])).toThrow(/positive integer/);
+  });
+
+  it('rejects unknown arguments', () => {
+    expect(() => parseArgs(['--what'])).toThrow(/Unknown argument/);
+  });
+
+  it('treats --help and -h as help requests', () => {
+    expect(parseArgs(['--help']).shouldPrintHelp).toBe(true);
+    expect(parseArgs(['-h']).shouldPrintHelp).toBe(true);
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/cli/run-chatbot.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/cli/run-chatbot.test.ts
@@ -1,0 +1,299 @@
+import type { ChatMessage } from '@workspaces/packages/llm-client';
+import { describe, expect, it } from 'vitest';
+
+import type { ChatSession } from '../../src/chat/chat-session.js';
+import type { ChatOptions, Messages } from '../../src/chat/types.js';
+import { runChatbot } from '../../src/cli/run-chatbot.js';
+import type { McpStdioClient } from '../../src/client/mcp-client.js';
+
+const noop = (_text: string): void => {
+  void _text;
+};
+
+function fakeDocumentServer(documents: Record<string, string>): McpStdioClient {
+  return {
+    callTool: () =>
+      Promise.resolve({ content: [] } as unknown as Awaited<
+        ReturnType<McpStdioClient['callTool']>
+      >),
+    close: () => Promise.resolve(),
+    getPrompt: (name, args) => {
+      if (name !== 'format') {
+        return Promise.reject(new Error(`Unknown prompt: ${name}`));
+      }
+
+      const docId = args?.doc_id ?? 'unknown';
+
+      return Promise.resolve({
+        messages: [
+          {
+            content: { text: `format ${docId}`, type: 'text' },
+            role: 'user',
+          },
+        ],
+      } as unknown as Awaited<ReturnType<McpStdioClient['getPrompt']>>);
+    },
+    listPrompts: () =>
+      Promise.resolve([
+        {
+          arguments: [{ name: 'doc_id', required: true }],
+          description: 'Format a document',
+          name: 'format',
+        },
+      ] as unknown as Awaited<ReturnType<McpStdioClient['listPrompts']>>),
+    listResources: () =>
+      Promise.resolve([] as unknown as Awaited<ReturnType<McpStdioClient['listResources']>>),
+    listResourceTemplates: () =>
+      Promise.resolve(
+        [] as unknown as Awaited<ReturnType<McpStdioClient['listResourceTemplates']>>,
+      ),
+    listTools: () =>
+      Promise.resolve([] as unknown as Awaited<ReturnType<McpStdioClient['listTools']>>),
+    readResource: (uri: string) => {
+      if (uri === 'docs://documents') {
+        return Promise.resolve({
+          contents: [
+            {
+              mimeType: 'application/json',
+              text: JSON.stringify({ documents: Object.keys(documents) }),
+              uri,
+            },
+          ],
+        } as unknown as Awaited<ReturnType<McpStdioClient['readResource']>>);
+      }
+
+      const docId = uri.replace('docs://documents/', '');
+      const text = documents[docId];
+
+      if (text === undefined) {
+        return Promise.reject(new Error(`Unknown document: ${docId}`));
+      }
+
+      return Promise.resolve({
+        contents: [{ mimeType: 'text/plain', text, uri }],
+      } as unknown as Awaited<ReturnType<McpStdioClient['readResource']>>);
+    },
+  };
+}
+
+function fakeSession(): {
+  appended: ChatMessage[];
+  messages: { options: ChatOptions; text: string }[];
+  session: ChatSession;
+} {
+  const history: Messages = [];
+  const appended: ChatMessage[] = [];
+  const messages: { options: ChatOptions; text: string }[] = [];
+  const session: ChatSession = {
+    appendMessages: (msgs) => {
+      appended.push(...msgs);
+      history.push(...msgs);
+    },
+    get history() {
+      return history;
+    },
+    sendUserMessage: (text, options = {}) => {
+      messages.push({ options, text });
+      history.push({ content: text, role: 'user' });
+      const answer = `echo: ${text}`;
+      history.push({ content: answer, role: 'assistant' });
+
+      return Promise.resolve(answer);
+    },
+  };
+
+  return { appended, messages, session };
+}
+
+function streamingToolSession(): ChatSession {
+  const history: Messages = [];
+
+  return {
+    appendMessages: (messages) => {
+      history.push(...messages);
+    },
+    get history() {
+      return history;
+    },
+    sendUserMessage: (text, options = {}) => {
+      history.push({ content: text, role: 'user' });
+      options.onTextDelta?.('partial response');
+      options.onToolEvent?.({ toolName: 'read_doc_contents', type: 'tool_running' });
+      history.push({ content: 'done', role: 'assistant' });
+
+      return Promise.resolve('done');
+    },
+  };
+}
+
+function scriptInput(turns: readonly string[]): () => Promise<string> {
+  const queue = [...turns];
+
+  return () => {
+    const next = queue.shift();
+
+    if (next === undefined) {
+      return Promise.reject(new Error('input closed'));
+    }
+
+    return Promise.resolve(next);
+  };
+}
+
+describe('runChatbot', () => {
+  it('handles a plain user turn and prints the answer when not streaming', async () => {
+    const documentServer = fakeDocumentServer({});
+    const { messages, session } = fakeSession();
+    const outputs: string[] = [];
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['hi']),
+      output: (text) => outputs.push(text),
+      outputChunk: noop,
+      session,
+      stream: false,
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.text).toBe('hi');
+    expect(outputs).toContain('echo: hi');
+  });
+
+  it('lists prompts when the user submits "/"', async () => {
+    const documentServer = fakeDocumentServer({});
+    const { messages, session } = fakeSession();
+    const outputs: string[] = [];
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['/']),
+      output: (text) => outputs.push(text),
+      outputChunk: noop,
+      session,
+    });
+
+    expect(messages).toHaveLength(0);
+    expect(outputs.some((line) => line.includes('/format'))).toBe(true);
+  });
+
+  it('lists documents when the user submits "@"', async () => {
+    const documentServer = fakeDocumentServer({ 'a.md': 'x', 'b.md': 'y' });
+    const { messages, session } = fakeSession();
+    const outputs: string[] = [];
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['@']),
+      output: (text) => outputs.push(text),
+      outputChunk: noop,
+      session,
+    });
+
+    expect(messages).toHaveLength(0);
+    expect(outputs.some((line) => line.includes('@a.md') && line.includes('@b.md'))).toBe(true);
+  });
+
+  it('runs /format doc_id by routing through the prompt', async () => {
+    const documentServer = fakeDocumentServer({ 'a.md': 'alpha' });
+    const { messages, session } = fakeSession();
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['/format a.md']),
+      output: noop,
+      outputChunk: noop,
+      session,
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.text).toBe('format a.md');
+  });
+
+  it('rejects /format without doc_id', async () => {
+    const documentServer = fakeDocumentServer({});
+    const { messages, session } = fakeSession();
+    const outputs: string[] = [];
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['/format']),
+      output: (text) => outputs.push(text),
+      outputChunk: noop,
+      session,
+    });
+
+    expect(messages).toHaveLength(0);
+    expect(outputs.some((line) => line.includes('requires argument'))).toBe(true);
+  });
+
+  it('injects document context when the user mentions @doc', async () => {
+    const documentServer = fakeDocumentServer({ 'a.md': 'alpha content' });
+    const { messages, session } = fakeSession();
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['please read @a.md']),
+      output: noop,
+      outputChunk: noop,
+      session,
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.text).toContain('<document id="a.md">');
+    expect(messages[0]?.text).toContain('alpha content');
+    expect(messages[0]?.text).toContain('please read @a.md');
+  });
+
+  it('warns about unknown @doc mentions but still runs the turn', async () => {
+    const documentServer = fakeDocumentServer({ 'a.md': 'alpha' });
+    const { messages, session } = fakeSession();
+    const outputs: string[] = [];
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['ask about @missing.md']),
+      output: (text) => outputs.push(text),
+      outputChunk: noop,
+      session,
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(outputs.some((line) => line.includes('Unknown document'))).toBe(true);
+  });
+
+  it('passes onTextDelta and onToolEvent through to chat options', async () => {
+    const documentServer = fakeDocumentServer({});
+    const { messages, session } = fakeSession();
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['hi']),
+      output: noop,
+      outputChunk: noop,
+      session,
+    });
+
+    expect(messages[0]?.options.onTextDelta).toBeDefined();
+    expect(messages[0]?.options.onToolEvent).toBeDefined();
+    expect(messages[0]?.options.stream).toBe(true);
+  });
+
+  it('prints a line break before tool status after streamed text', async () => {
+    const documentServer = fakeDocumentServer({});
+    const outputs: string[] = [];
+    const chunks: string[] = [];
+
+    await runChatbot({
+      documentServer,
+      input: scriptInput(['hi']),
+      output: (text) => outputs.push(text),
+      outputChunk: (text) => chunks.push(text),
+      session: streamingToolSession(),
+    });
+
+    expect(chunks).toEqual(['partial response']);
+    expect(outputs).toContain('');
+    expect(outputs).toContain('[tool] Running read_doc_contents');
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/client/mcp-client.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/client/mcp-client.test.ts
@@ -1,0 +1,55 @@
+import { Client } from '@modelcontextprotocol/client';
+import { describe, expect, it } from 'vitest';
+
+import { connectMcpStdioClient } from '../../src/client/mcp-client.js';
+import { createDocumentStore } from '../../src/documents/document-store.js';
+import { createDocumentMcpServer } from '../../src/server/document-mcp-server.js';
+import { createPairedTransports } from '../support/in-memory-transport.js';
+
+async function buildInMemoryClient() {
+  const store = createDocumentStore({ 'a.md': 'aaa', 'b.md': 'bbb', 'c.md': 'ccc' });
+  const server = createDocumentMcpServer(store);
+  const { clientTransport, serverTransport } = createPairedTransports();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'paginate-client', version: '0.0.0' });
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe('mcp client wrapper', () => {
+  it('lists tools, resources, resource templates, and prompts', async () => {
+    const { client, close } = await buildInMemoryClient();
+
+    try {
+      const toolsResult = await client.listTools();
+      const toolNames = toolsResult.tools.map((tool) => tool.name).toSorted();
+      expect(toolNames).toEqual(['edit_document', 'read_doc_contents']);
+
+      const resourcesResult = await client.listResources();
+      expect(resourcesResult.resources.map((resource) => resource.uri)).toContain(
+        'docs://documents',
+      );
+
+      const templatesResult = await client.listResourceTemplates();
+      expect(templatesResult.resourceTemplates.map((template) => template.uriTemplate)).toContain(
+        'docs://documents/{doc_id}',
+      );
+
+      const promptsResult = await client.listPrompts();
+      expect(promptsResult.prompts.map((prompt) => prompt.name)).toContain('format');
+    } finally {
+      await close();
+    }
+  });
+
+  it('exposes connectMcpStdioClient for stdio connections', () => {
+    expect(typeof connectMcpStdioClient).toBe('function');
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/documents/document-store.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/documents/document-store.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createDocumentStore,
+  DocumentEditError,
+  DocumentNotFoundError,
+} from '../../src/documents/document-store.js';
+
+const seed = {
+  'a.md': 'Hello world',
+  'b.md': 'one two three\none two three',
+} as const;
+
+describe('document store', () => {
+  it('lists document ids sorted', () => {
+    const store = createDocumentStore(seed);
+
+    expect(store.listDocumentIds()).toEqual(['a.md', 'b.md']);
+  });
+
+  it('reads existing documents', () => {
+    const store = createDocumentStore(seed);
+
+    expect(store.readDocument('a.md')).toBe('Hello world');
+  });
+
+  it('throws DocumentNotFoundError for missing documents', () => {
+    const store = createDocumentStore(seed);
+
+    expect(() => store.readDocument('missing.md')).toThrow(DocumentNotFoundError);
+  });
+
+  it('edits a unique substring', () => {
+    const store = createDocumentStore(seed);
+    const result = store.editDocument({ docId: 'a.md', newStr: 'planet', oldStr: 'world' });
+
+    expect(result).toEqual({ docId: 'a.md', replacements: 1 });
+    expect(store.readDocument('a.md')).toBe('Hello planet');
+  });
+
+  it('fails when old_str is empty', () => {
+    const store = createDocumentStore(seed);
+
+    expect(() => store.editDocument({ docId: 'a.md', newStr: 'x', oldStr: '' })).toThrow(
+      DocumentEditError,
+    );
+  });
+
+  it('fails when old_str is missing', () => {
+    const store = createDocumentStore(seed);
+
+    expect(() => store.editDocument({ docId: 'a.md', newStr: 'x', oldStr: 'nope' })).toThrow(
+      DocumentEditError,
+    );
+  });
+
+  it('fails when old_str matches multiple times', () => {
+    const store = createDocumentStore(seed);
+
+    expect(() =>
+      store.editDocument({ docId: 'b.md', newStr: 'X', oldStr: 'one two three' }),
+    ).toThrow(/multiple times|matched 2 times/i);
+  });
+
+  it('fails for missing document on edit', () => {
+    const store = createDocumentStore(seed);
+
+    expect(() => store.editDocument({ docId: 'missing.md', newStr: 'x', oldStr: 'y' })).toThrow(
+      DocumentNotFoundError,
+    );
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/server/document-mcp-server.test.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/server/document-mcp-server.test.ts
@@ -1,0 +1,183 @@
+import { Client } from '@modelcontextprotocol/client';
+import { describe, expect, it } from 'vitest';
+
+import { createDocumentStore } from '../../src/documents/document-store.js';
+import {
+  DOCUMENTS_LIST_URI,
+  createDocumentMcpServer,
+} from '../../src/server/document-mcp-server.js';
+import { createPairedTransports } from '../support/in-memory-transport.js';
+
+const seed = {
+  'a.md': 'Hello world',
+  'b.md': 'one two three',
+} as const;
+
+async function connectInMemory(): Promise<{ client: Client; close: () => Promise<void> }> {
+  const store = createDocumentStore(seed);
+  const server = createDocumentMcpServer(store);
+  const { clientTransport, serverTransport } = createPairedTransports();
+
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe('document MCP server', () => {
+  it('lists registered tools', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name).toSorted();
+
+      expect(names).toEqual(['edit_document', 'read_doc_contents']);
+    } finally {
+      await close();
+    }
+  });
+
+  it('reads a document via the read_doc_contents tool', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const result = await client.callTool({
+        arguments: { doc_id: 'a.md' },
+        name: 'read_doc_contents',
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({
+        content: 'Hello world',
+        doc_id: 'a.md',
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns isError=true for a missing document', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const result = await client.callTool({
+        arguments: { doc_id: 'missing.md' },
+        name: 'read_doc_contents',
+      });
+
+      expect(result.isError).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it('edits a document via edit_document', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const result = await client.callTool({
+        arguments: { doc_id: 'a.md', new_str: 'planet', old_str: 'world' },
+        name: 'edit_document',
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toMatchObject({
+        doc_id: 'a.md',
+        replacements: 1,
+        updated: true,
+      });
+
+      const after = await client.callTool({
+        arguments: { doc_id: 'a.md' },
+        name: 'read_doc_contents',
+      });
+
+      expect(after.structuredContent).toMatchObject({ content: 'Hello planet' });
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns isError=true when edit_document old_str is missing', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const result = await client.callTool({
+        arguments: { doc_id: 'a.md', new_str: 'x', old_str: 'nope' },
+        name: 'edit_document',
+      });
+
+      expect(result.isError).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it('lists documents through the docs://documents resource', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const result = await client.readResource({ uri: DOCUMENTS_LIST_URI });
+      const first = result.contents[0];
+
+      expect(first).toBeDefined();
+      expect(first?.mimeType).toBe('application/json');
+      const payload = JSON.parse((first as { text: string }).text) as { documents: string[] };
+      expect(payload.documents.toSorted()).toEqual(['a.md', 'b.md']);
+    } finally {
+      await close();
+    }
+  });
+
+  it('reads an individual document via the template URI', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const result = await client.readResource({ uri: 'docs://documents/b.md' });
+      const first = result.contents[0];
+
+      expect((first as { text: string }).text).toBe('one two three');
+    } finally {
+      await close();
+    }
+  });
+
+  it('lists prompts including format', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const { prompts } = await client.listPrompts();
+
+      expect(prompts.map((p) => p.name)).toContain('format');
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns format prompt messages with the doc_id reference', async () => {
+    const { client, close } = await connectInMemory();
+
+    try {
+      const result = await client.getPrompt({ arguments: { doc_id: 'a.md' }, name: 'format' });
+      const first = result.messages[0];
+
+      expect(first?.role).toBe('user');
+
+      if (first?.content.type === 'text') {
+        expect(first.content.text).toMatch(/a\.md/);
+      } else {
+        throw new Error('expected first message to be text content');
+      }
+    } finally {
+      await close();
+    }
+  });
+});

--- a/workspaces/ai-engineering/mcp-chat/tests/support/in-memory-transport.ts
+++ b/workspaces/ai-engineering/mcp-chat/tests/support/in-memory-transport.ts
@@ -1,0 +1,56 @@
+import type { JSONRPCMessage, Transport } from '@modelcontextprotocol/client';
+
+interface PairedTransport extends Transport {
+  pair(other: InMemoryTransport): void;
+}
+
+class InMemoryTransport implements PairedTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+  private closed = false;
+  private peer?: InMemoryTransport;
+
+  pair(other: InMemoryTransport): void {
+    this.peer = other;
+  }
+
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  send(message: JSONRPCMessage): Promise<void> {
+    if (this.peer === undefined) {
+      return Promise.reject(new Error('InMemoryTransport not paired'));
+    }
+
+    queueMicrotask(() => {
+      this.peer?.onmessage?.(message);
+    });
+
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    if (this.closed) {
+      return Promise.resolve();
+    }
+
+    this.closed = true;
+    this.onclose?.();
+
+    return Promise.resolve();
+  }
+}
+
+export function createPairedTransports(): {
+  clientTransport: Transport;
+  serverTransport: Transport;
+} {
+  const server = new InMemoryTransport();
+  const client = new InMemoryTransport();
+  server.pair(client);
+  client.pair(server);
+
+  return { clientTransport: client, serverTransport: server };
+}

--- a/workspaces/ai-engineering/mcp-chat/tsconfig.json
+++ b/workspaces/ai-engineering/mcp-chat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "paths": {
+      "@workspaces/packages/llm-client": ["../../packages/llm-client/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts", "esbuild.config.mjs"]
+}

--- a/workspaces/ai-engineering/mcp-chat/vitest.config.ts
+++ b/workspaces/ai-engineering/mcp-chat/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@workspaces/packages/llm-client': path.resolve(
+        import.meta.dirname,
+        '../../packages/llm-client/src/index.ts',
+      ),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Why:
- Add an AI-engineering example for exploring MCP server/client workflows with Claude-backed chat.

What:
- Add an in-memory document MCP server with tools, resources, and a format prompt.
- Add a CLI chatbot with stdio MCP client integration, streaming, @document context, and slash commands.
- Add package scripts, docs, seeded documents, and Vitest coverage for the server, client, chat flow, and CLI.