### PR TITLE
Add ADR practice and tighten agent workflows

### DIFF
--- a/.agents/checklists/backend-api.md
+++ b/.agents/checklists/backend-api.md
@@ -3,6 +3,8 @@
 - Route path, HTTP method, and resource naming are clear.
 - Request body, query, params, and headers are validated.
 - Response shape is documented or consistent with existing API style.
+- Contract-breaking changes are identified: removed or renamed fields, narrowed types, new required inputs, changed status codes.
+- Each breaking change carries a deliberate compatibility decision; when the app publishes a contract, the regenerated spec diff is the evidence.
 - Status codes match success, validation, auth, not found, conflict, and server-error cases.
 - Error response shape is stable and does not leak internals.
 - Authn and authz are enforced at the correct boundary.

--- a/.agents/rules/repo-map.md
+++ b/.agents/rules/repo-map.md
@@ -14,6 +14,9 @@ Project-specific orientation for AI agents. Keep this file easy to edit when cop
   `docs/architecture/`; Mermaid workflow diagrams live with their owning
   workspace under `workspaces/**/docs/`. Conventions are in
   `docs/architecture/README.md`.
+- Architecture decision records live under `docs/adr/`. Read
+  `docs/adr/README.md` before recording a decision; it owns the numbering,
+  required sections, and status lifecycle.
 - Shared AI-agent material lives under `.agents/*`. Tool-specific adapters live under `.claude/`, `.codex/`, `.cursor/`, or `.github/` and should stay thin (see [.agents/README.md](../README.md) for design rules).
 
 ## Context Loading Policy

--- a/.agents/skills/backend-api-change/SKILL.md
+++ b/.agents/skills/backend-api-change/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: backend-api-change
-description: Backend API route and contract changes for HTTP handlers, controllers, services, middleware, request/response schemas, validation, status codes, and API errors. Use when adding or changing backend API behavior.
+description: Backend API route, endpoint, and contract changes for HTTP handlers, controllers, services, middleware, request/response schemas, OpenAPI/contract specs, validation, status codes, and API errors. Use when adding or changing backend API behavior.
 metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-05-05'
+  last-reviewed: '2026-07-22'
 ---
 
 # Backend API Change
@@ -42,7 +42,8 @@ Implement backend API changes while preserving contracts, validation, layering, 
 5. Keep business logic out of route handlers where possible.
 6. Add or update unit/integration tests for normal and edge cases.
 7. Update docs, examples, or API notes when behavior changes.
-8. Report status codes, edge cases, and validation performed.
+8. When the app publishes a contract spec, regenerate it from the boundary schemas through its owning command instead of editing the generated file, and review the regenerated diff against the [backend-api checklist](../../checklists/backend-api.md) for breaking changes.
+9. Report status codes, edge cases, and validation performed.
 
 ## Output Format
 

--- a/.agents/skills/data-storage-change/SKILL.md
+++ b/.agents/skills/data-storage-change/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: data-storage-change
-description: Data storage and persistence changes for schemas, migrations, indexes, queries, caching, repositories, transactions, and data access. Use when changing how data is stored or retrieved.
+description: Data storage and persistence changes for databases, tables, columns, schemas, migrations, indexes, queries, caching, repositories, transactions, and data access. Use when changing how data is stored or retrieved.
 metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-05-05'
+  last-reviewed: '2026-07-22'
 ---
 
 # Data Storage Change

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-07-15'
+  last-reviewed: '2026-07-22'
 ---
 
 # Debug
@@ -36,21 +36,28 @@ Find a reproducible root cause and, when implementation is requested, apply the 
 ## Workflow
 
 1. Capture the exact error and failing command.
-2. Find the shortest reproduction path.
+2. Run the shortest reproduction path and capture the actual output. If the bug does not reproduce, try other evidence-backed triggering conditions before concluding.
 3. Inspect recent changes and nearby code.
 4. Form 2-3 plausible hypotheses.
-5. Test hypotheses one by one.
-6. If implementation is requested, fix the minimal root cause.
-7. When a fix is made, add or update a regression test when practical.
-8. Report the root cause and validation.
+5. Test hypotheses one by one until the root cause, violated invariant, and relevant `file:line` locations are supported by evidence.
+6. Before changing code, state why the planned change closes the violated invariant. If that explanation does not map to the identified root cause, reconsider — the change is probably targeting a symptom.
+7. If implementation is requested, fix the minimal root cause.
+8. When a fix is made, add or update a regression test when practical, in the project's real test suite and matching its existing framework and naming conventions.
+9. When a fix is made, re-run the reproduction against the fixed code and show the actual output. An assertion that it should now pass is not evidence.
+10. When a fix is made, check its side effects: name the behavior near the change that could break (null and empty cases, boundaries, concurrent callers, changed error types, ordering, performance), each with a concrete triggering input and the `file:line` where behavior diverges. If none apply, name the callers and inputs checked and why each is unaffected.
+11. Scan for the same wrong assumption elsewhere in the codebase. Report matches as `file:line` plus a short excerpt and the searches run; report no matches only alongside at least two distinct searches. Do not expand the current fix to cover them — raise them as follow-ups.
+12. Report the root cause and validation.
 
 ## Output Format
 
 - Symptom.
-- Reproduction.
-- Root cause.
+- Reproduction evidence: exact command and actual failing output.
+- Root cause and violated invariant, with `file:line` when applicable.
 - Fix, when implemented.
 - Regression coverage, when implemented.
+- Re-run evidence, when implemented: actual output after the fix.
+- Side effects checked, when implemented, including the callers and inputs behind a "none apply" conclusion.
+- Similar patterns found (`file:line` plus a short excerpt), or the searches run that found none.
 - Validation.
 - Remaining risk.
 
@@ -60,6 +67,7 @@ Find a reproducible root cause and, when implementation is requested, apply the 
 - Do not add noisy logs unless they are removed or intentionally structured.
 - Avoid broad rewrites during debugging.
 - Keep diagnosis-only requests read-only; apply a fix only when the user requests implementation or the request otherwise clearly includes it.
+- After three failed approaches to the same mechanical step (running a reproduction, locating a function, parsing output, detecting the test framework, executing tests), report the approaches and observed results, then ask one specific question instead of inventing further variants. Analytical uncertainty is not a blocker — pick the best-supported hypothesis, state confidence, and continue.
 
 ## When Not To Use
 

--- a/.claude/skills/backend-api-change/SKILL.md
+++ b/.claude/skills/backend-api-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-api-change
-description: Backend API route and contract changes for HTTP handlers, controllers, services, middleware, request/response schemas, validation, status codes, and API errors. Use when adding or changing backend API behavior.
+description: Backend API route, endpoint, and contract changes for HTTP handlers, controllers, services, middleware, request/response schemas, OpenAPI/contract specs, validation, status codes, and API errors. Use when adding or changing backend API behavior.
 argument-hint: '[route, endpoint, or API behavior]'
 ---
 

--- a/.claude/skills/data-storage-change/SKILL.md
+++ b/.claude/skills/data-storage-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-storage-change
-description: Data storage and persistence changes for schemas, migrations, indexes, queries, caching, repositories, transactions, and data access. Use when changing how data is stored or retrieved.
+description: Data storage and persistence changes for databases, tables, columns, schemas, migrations, indexes, queries, caching, repositories, transactions, and data access. Use when changing how data is stored or retrieved.
 argument-hint: '[schema, query, migration, or repository change]'
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ All topic content is sharded into per-topic folders under [\_todo/](./_todo/). E
 
 ## Repo Pointers
 
+- Architecture decisions: [docs/adr/](./adr/) — numbered records of consequential choices and
+  their trade-offs.
 - Real apps: [workspaces/apps/shop-mvc-express/](../workspaces/apps/shop-mvc-express/), [workspaces/apps/local-llm-playground/](../workspaces/apps/local-llm-playground/)
 - Scaffold apps (committed order below): `auth-service`, `orders-event-driven`, `shop-feature-fastify`, `chat-ws`, `serverless-toolkit`
 - Scratch app briefs (deferred): `workspaces/apps/_todo/*` — `analytics-pipeline`, `bff-gateway`, `blog-graphql`, `iot-telemetry`, `media-service`, `payments-billing`, `shop-clean`, `shop-nest`.
@@ -109,10 +111,10 @@ milestones because realtime needs a separate app):
   `serverless-toolkit` vertical slice with API Gateway + Lambda, DynamoDB, S3
   presigned uploads, streaming downloads with backpressure, CloudFront
   delivery, and CDK-managed infrastructure.
-- **Phase 7 — system design and portfolio polish:** `docs/adr/` with the
-  first real ADRs; extend the C4 model and per-app workflow docs with the
-  backend apps; per-app "Interview story" README sections; verify every
-  `done` topic has code link + test link + interview answer.
+- **Phase 7 — system design and portfolio polish:** extend the C4 model and
+  per-app workflow docs with the backend apps; per-app "Interview story"
+  README sections; verify every `done` topic has code link + test link +
+  interview answer.
 
 ## Topic Index
 

--- a/docs/_todo/api-design/rest/README.md
+++ b/docs/_todo/api-design/rest/README.md
@@ -15,7 +15,7 @@
 
 - [ ] Implement product CRUD with Zod validation + 4xx/5xx mapping through HttpError (shop-mvc-express).
 - [ ] Add cursor-based pagination for product listing; reject invalid cursors with 400.
-- [ ] Pick a versioning strategy and write a one-page ADR in this folder.
+- [ ] Pick a versioning strategy and write a one-page ADR following the [repository ADR practice](../../../adr/).
 - [x] Author an OpenAPI 3.1 spec for shop-mvc-express's product endpoints from the Zod schemas ([document builder](../../../../workspaces/apps/shop-mvc-express/src/openapi/document.ts), [generated contract](../../../../workspaces/apps/shop-mvc-express/docs/openapi.json)).
 - [x] Serve the shop-mvc-express OpenAPI spec at `/docs`, mounted outside production only ([docs router](../../../../workspaces/apps/shop-mvc-express/src/routes/docs.routes.ts)).
 - [x] Lint and drift-check the shop-mvc-express OpenAPI spec in CI ([workspace scripts](../../../../workspaces/apps/shop-mvc-express/package.json), [CI gate](../../../../.github/workflows/ci.yml)).

--- a/docs/_todo/architecture-patterns/mvc-layered/README.md
+++ b/docs/_todo/architecture-patterns/mvc-layered/README.md
@@ -14,7 +14,7 @@
 - [ ] Keep shop-mvc-express on layered MVC; document the final module boundaries.
 - [ ] In shop-feature-fastify, create `src/modules/{products,users,orders,cart}` as Fastify plugins.
 - [ ] Add a `Repository` interface per module; inject implementation in the plugin root.
-- [ ] Write a short ADR in this file comparing MVC vs feature-based for the shop.
+- [ ] Write a short ADR comparing MVC vs feature-based for the shop, following the [repository ADR practice](../../../adr/).
 
 ## Concepts to know
 

--- a/docs/adr/0001-architecture-as-code-format.md
+++ b/docs/adr/0001-architecture-as-code-format.md
@@ -1,0 +1,52 @@
+# ADR-0001: Architecture-As-Code Format
+
+- **Status:** Accepted
+- **Decision date:** 2026-07-15
+- **Recorded:** 2026-07-22
+
+## Context
+
+The repository needed one reviewable model of its systems, containers, external services, and
+relationships. This is a retrospective record of the decision implemented in commit `d7b55f2`;
+`Proposed` means the record awaits human confirmation, not that the tooling is unimplemented.
+
+The [architecture guide](../architecture/README.md) establishes text-based diagrams in Git,
+with Structurizr DSL answering repo-level C4 questions and workspace-owned Mermaid files
+answering feature-workflow questions.
+
+## Decision
+
+Use [`workspace.dsl`](../architecture/workspace.dsl) as the source of truth for the repository C4
+model. Export its views to committed Mermaid files under `docs/architecture/generated/`, while
+keeping hand-written Mermaid workflow diagrams beside the workspaces that own them.
+
+Run Structurizr through the consolidated `structurizr/structurizr` Docker image pinned to the
+dated `2026.06.28` tag in both local scripts and CI.
+
+## Consequences
+
+- Architecture changes remain text-reviewable, versioned, and reproducible between local and CI
+  environments.
+- Generated views must be committed and refreshed whenever `workspace.dsl` changes.
+- Contributors need Docker to validate, export, or interactively view the C4 model.
+- The dated image pin avoids silent output drift but requires deliberate coordinated upgrades.
+
+## Alternatives
+
+- **Hand-written Mermaid only:** retained for feature workflows, but not for the C4 model because
+  Mermaid marks its C4 diagram types experimental and the repository needs one model source.
+- **LikeC4:** not adopted; the repository standardized its C4 source and validation/export path on
+  Structurizr. The surviving evidence does not preserve a deeper product comparison, so this
+  retrospective ADR does not invent one.
+- **The older `structurizr/cli` image:** not used because it is frozen and no longer updated.
+- **`structurizr/structurizr:latest`:** not used because a floating tag can make identical commits
+  validate or export differently over time.
+
+## Compliance
+
+- Run `pnpm run arch:validate` to validate the DSL and `pnpm run arch:export` (or `pnpm run arch`)
+  to regenerate the committed views; the commands and pin live in [`package.json`](../../package.json).
+- The path-scoped [`docs-architecture.yml`](../../.github/workflows/docs-architecture.yml)
+  workflow validates the DSL and diffs a fresh export against committed output.
+- Follow the [generated-files rule](../../.agents/rules/change-discipline.md): edit the DSL and
+  regenerate output instead of editing `docs/architecture/generated/**` by hand.

--- a/docs/adr/0002-api-contract-generation.md
+++ b/docs/adr/0002-api-contract-generation.md
@@ -1,0 +1,54 @@
+# ADR-0002: API Contract Generation
+
+- **Status:** Accepted
+- **Decision date:** 2026-07-22
+- **Recorded:** 2026-07-22
+
+## Context
+
+`shop-mvc-express` already validates product input with a boundary
+[Zod schema](../../workspaces/apps/shop-mvc-express/src/schemas/product.schema.ts). The app needed
+an OpenAPI contract for documentation, contract tests, and consumers without creating a second
+request-schema source.
+
+This is a retrospective record of the decision implemented in commit `550bb2f`; `Proposed` means
+the record awaits human confirmation, not that the published contract is unimplemented.
+
+## Decision
+
+Generate OpenAPI 3.1 from the Zod schemas with `zod-openapi`. Keep the
+[document builder](../../workspaces/apps/shop-mvc-express/src/openapi/document.ts) as the contract
+source, commit the generated `docs/openapi.json`, serve it at `/openapi.json`, and expose Swagger
+UI at `/docs/` outside production.
+
+## Consequences
+
+- Boundary schemas remain the source for runtime validation and OpenAPI schema metadata, reducing
+  contract drift.
+- The generated JSON is tool-owned and must never be edited by hand.
+- Changes to the contract require regeneration, linting, drift checks, and contract-test updates.
+- Contract generation is coupled to compatibility among Zod 4, `zod-openapi`, and the document
+  builder, so dependency changes require verification.
+
+## Alternatives
+
+- **A hand-written spec-first contract:** not selected because it would repeat the request shape
+  already enforced by Zod and create another source that could drift.
+- **`swagger-jsdoc` annotations:** not selected because comment annotations would separate the
+  contract from the executable boundary schemas and could drift independently.
+- **A plain hand-assembled OpenAPI object:** not selected because independently repeating schemas
+  would add manual wiring and lose the schema reuse provided by `zod-openapi`.
+
+## Compliance
+
+- Generate with `pnpm --filter shop-mvc-express openapi:generate`; the
+  [generator](../../workspaces/apps/shop-mvc-express/scripts/generate-openapi.ts) formats the
+  artifact and its check mode rejects missing or stale output.
+- `pnpm --filter shop-mvc-express openapi:check` also runs Redocly lint, and the
+  [main CI workflow](../../.github/workflows/ci.yml) invokes it for changed workspaces.
+- The [OpenAPI tests](../../workspaces/apps/shop-mvc-express/tests/openapi.test.ts) verify the served
+  contract and Swagger UI, while the
+  [product contract tests](../../workspaces/apps/shop-mvc-express/tests/api/products.test.ts)
+  compare implemented responses with the document.
+- Follow the [generated-files rule](../../.agents/rules/change-discipline.md): change schemas or
+  the document builder, then regenerate `docs/openapi.json`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,8 +7,8 @@ choices. Keep each ADR short, evidence-based, and linked from this index.
 
 | Number | Decision                                                             | Status   | Date       |
 | ------ | -------------------------------------------------------------------- | -------- | ---------- |
-| 0001   | [Architecture-as-code format](./0001-architecture-as-code-format.md) | Proposed | 2026-07-15 |
-| 0002   | [API contract generation](./0002-api-contract-generation.md)         | Proposed | 2026-07-22 |
+| 0001   | [Architecture-as-code format](./0001-architecture-as-code-format.md) | Accepted | 2026-07-15 |
+| 0002   | [API contract generation](./0002-api-contract-generation.md)         | Accepted | 2026-07-22 |
 
 ## When An ADR Is Required
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,55 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) preserve the reasoning behind consequential repository
+choices. Keep each ADR short, evidence-based, and linked from this index.
+
+## Index
+
+| Number | Decision                                                             | Status   | Date       |
+| ------ | -------------------------------------------------------------------- | -------- | ---------- |
+| 0001   | [Architecture-as-code format](./0001-architecture-as-code-format.md) | Proposed | 2026-07-15 |
+| 0002   | [API contract generation](./0002-api-contract-generation.md)         | Proposed | 2026-07-22 |
+
+## When An ADR Is Required
+
+Write an ADR when a lasting decision answers yes to any of these questions:
+
+- Is it hard or costly to reverse?
+- Does it affect more than one system or team?
+- Does it constrain how the rest of the system must be built?
+
+Skip routine implementation details whose rationale is already clear from the code.
+
+## Format
+
+- Name files `NNNN-kebab-title.md` with a zero-padded, increasing number.
+- Never renumber an ADR, including after it is superseded.
+- Open with a header block of `Status`, `Decision date` (when the choice was made), and
+  `Recorded` (when this file was written — the same day unless the record is retrospective).
+- Include five sections: `Context`, `Decision`, `Consequences`, `Alternatives`, and
+  `Compliance`.
+- Cite repository evidence and identify retrospective records explicitly.
+- Add an index row carrying the ADR's `Decision date`, and change `Status` in the ADR file and
+  its index row together.
+
+## Writing An ADR
+
+- Fill in the ADR **while the decision is being made**, not after it ships. Capture the
+  reasoning and alternatives weighed, not only the outcome; retrospective records are allowed
+  but lossy and must say so.
+- Record the **least bad trade-off for this repository right now**, including its costs; there is
+  no universally right answer.
+- Use AI for **questions, options, and risks—never for the decision**. Ask what must be answered
+  first, compare three or four realistic options with honest trade-offs, and attack the chosen
+  option.
+- Before proposing acceptance, have the decision **attacked in a fresh session** that receives
+  the shared context but not the prior reasoning thread. Fold findings into `Consequences` or
+  change the decision; stop when a fresh attack finds no new significant risks, not at zero risk.
+
+## Status
+
+The lifecycle is `Proposed` → `Accepted` → `Superseded by NNNN`. An ADR remains `Proposed`
+until a human has read it and confirmed that it accurately records the decision and trade-offs.
+
+Every `Proposed` row in the index is therefore an open review action, not a finished record. The
+index is the tracker — no separate follow-up list is needed.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,6 +16,9 @@ they describe. Two formats, split by the question they answer:
 Do not use Mermaid's `C4Context`/`C4Container` diagram types — Mermaid marks
 them experimental. C4 belongs in `workspace.dsl`.
 
+The reasoning behind this split, and the alternatives rejected, is recorded in
+[ADR-0001](../adr/0001-architecture-as-code-format.md).
+
 ## Layout
 
 ```text


### PR DESCRIPTION
## Summary

Adds a lightweight ADR practice and records the existing architecture-as-code and generated OpenAPI decisions. It also strengthens reusable agent guidance for API compatibility, data-storage discovery, and evidence-driven debugging.

## Changes

- **Architecture decisions** - Add ADR conventions and two retrospective decision records, then link them from the architecture guide and learning roadmap.
- **API guidance** - Require breaking-change identification, deliberate compatibility decisions, and generated contract review while expanding relevant skill triggers.
- **Debugging workflow** - Require executed reproductions, invariant-based fixes, post-fix evidence, side-effect analysis, regression coverage, and similar-pattern searches.
- **Tool adapters** - Keep Claude skill descriptions aligned with their canonical agent skills.