### PR TITLE
Strengthen AI engineering review guardrails

### DIFF
--- a/.agents/agents/security-reviewer.md
+++ b/.agents/agents/security-reviewer.md
@@ -8,6 +8,7 @@ Review changes for security risks across auth, authorization, input validation, 
 
 - A change touches auth, authorization, validation, data exposure, secrets, logging, uploads, webhooks, rate limits, CORS, headers, dependencies, MCP, or hooks.
 - A PR needs a security-focused pass.
+- When the change touches multi-tenant or resource-scoped access, state the threat model before reviewing — attacker, goal, and entry points — and review against it rather than against a generic vulnerability list.
 
 ## Pairs With
 
@@ -19,7 +20,7 @@ Review changes for security risks across auth, authorization, input validation, 
 
 ## Output Contributions
 
-- Critical, high, and low-severity findings with evidence and file references.
+- Findings labeled with the shared severity and confidence scales from the [code-review skill](../skills/code-review/SKILL.md#severity--confidence), with evidence and file references. An exploitable issue on a live path is must-fix with high confidence.
 - Required validation.
 
 ## Boundaries
@@ -27,3 +28,5 @@ Review changes for security risks across auth, authorization, input validation, 
 - Read-only. Do not perform invasive security testing without explicit approval.
 - Do not print secret values; identify file, location, and class of exposure.
 - Prioritize exploitable issues over theoretical style concerns.
+- A clean pass is not evidence of security. State what was examined and what was not; never report the absence of findings as an assurance that the change is safe.
+- Findings on critical paths — authentication, authorization, payments, data export, and anything handling sensitive data — require explicit human sign-off. Do not close them on the review's own conclusion.

--- a/.agents/checklists/code-review.md
+++ b/.agents/checklists/code-review.md
@@ -13,6 +13,7 @@ Use for diff-focused reviews. Lead with blocking issues and keep suggestions sma
 - Does the code follow existing layering and module boundaries?
 - Are route handlers thin where the repo expects service or repository layers?
 - Is new abstraction justified by real duplication or complexity?
+- Does any function, class, or module accumulate unrelated responsibilities, or reach repeatedly into another object's internals instead of asking it for behavior?
 - Does every workspace package imported by the diff (`@workspaces/...`) appear as a declared `workspace:*` dependency in the consuming package's manifest, not just a resolvable TypeScript path alias?
 
 ## Typing
@@ -20,11 +21,14 @@ Use for diff-focused reviews. Lead with blocking issues and keep suggestions sma
 - Are TypeScript types precise and narrow?
 - Are schemas used at external boundaries?
 - Is `any` avoided or clearly contained?
+- Are magic numbers and magic strings replaced by named constants, enums, or domain types when the value carries domain meaning?
+- Are lint and type suppressions (`eslint-disable*`, `@ts-expect-error`, `@ts-ignore`) justified in writing and scoped as narrowly as possible?
 
 ## Errors
 
 - Are typed errors mapped to correct outcomes?
 - Are internal errors hidden from clients?
+- Does the change fix the failure or only silence it? Flag broadened `catch` blocks, swallowed errors, new fallback defaults, removed validation, and relaxed assertions when they make a symptom disappear without addressing the cause.
 - Are logs useful without exposing secrets or sensitive data?
 
 ## Tests

--- a/.agents/checklists/pr-readiness.md
+++ b/.agents/checklists/pr-readiness.md
@@ -1,11 +1,14 @@
 # PR Readiness Checklist
 
 - Diff is focused on one coherent change.
+- The diff is small enough to review in one sitting — beyond roughly 400 changed lines, it is split or the PR explains why it must land together.
 - Unrelated refactors, formatting churn, and dependency upgrades are absent or explained.
 - Tests, typecheck, lint, build, or relevant checks were run and reported.
 - Docs, examples, API notes, or migration instructions are updated when behavior changes.
 - Migration, rollout, and rollback notes are included when data or config changes.
 - Risks and follow-ups are explicit.
+- The PR names what needs human eyes: the riskiest part of the diff and anything that was not verified.
+- AI review findings are addressed, or each one left unaddressed carries a written reason.
 - Screenshots, recordings, API examples, or curl output are included when relevant.
 - No secrets, tokens, private URLs, credentials, or local absolute paths are included.
 - Commit message and PR description match the actual diff.

--- a/.agents/checklists/security-review.md
+++ b/.agents/checklists/security-review.md
@@ -3,9 +3,13 @@
 - Input validation exists at every external boundary.
 - Authn verifies identity, token/session expiry, and invalid credentials.
 - Authz checks tenant, org, owner, role, and action scope where relevant.
+- Authorization failures on resources whose existence is itself sensitive return 404 rather than 403.
 - Secrets, API keys, tokens, passwords, and private URLs are not committed or logged.
 - Dependency changes are necessary and do not introduce obvious supply-chain risk.
-- SQL, shell, template, URL, path, and serialization injection risks are handled.
+- SQL, shell, template, URL, path, and serialization injection risks are handled; identifiers such as table, column, and sort keys use an allowlist, since parameterization does not cover them.
+- Password storage uses a slow, salted algorithm (Argon2, scrypt, or bcrypt) rather than a bare fast hash; security-sensitive tokens and intentionally unguessable identifiers come from a CSPRNG; symmetric encryption is authenticated, never ECB, and follows the algorithm's nonce or IV requirements (for AES-GCM, uniqueness per key is mandatory, and deterministic and approved random constructions are both valid).
+- Outbound requests to user-supplied URLs are SSRF-guarded: internal, link-local, and cloud-metadata addresses are blocked, redirects are not followed blindly, and timeout and response size are capped.
+- Request payloads map onto entities through an explicit field allowlist; no bulk assignment of arbitrary keys onto a model.
 - Sensitive data is redacted from logs, errors, traces, analytics, and test fixtures.
 - Rate limiting, request-size limits, and abuse controls exist where needed.
 - CORS, security headers, cookies, CSRF, and CSP are handled where relevant.

--- a/.agents/rules/change-discipline.md
+++ b/.agents/rules/change-discipline.md
@@ -7,6 +7,7 @@ Use this rule when editing code, docs, tests, config, or automation.
 - Do not make unrelated refactors, renames, formatting sweeps, or dependency changes.
 - Do not upgrade dependencies unless the task requires it or the current version blocks the work.
 - Do not hand-edit generated or tool-owned files; change them through their owning commands instead — e.g. `docs/architecture/generated/**` via `pnpm run arch:export`, `workspaces/apps/shop-mvc-express/docs/openapi.json` via `pnpm --filter shop-mvc-express openapi:generate`, and `pnpm-lock.yaml` via pnpm commands.
+- Every suppression carries a written reason on the same line or directly above it, and stays as narrow as possible — `eslint-disable*`, `@ts-expect-error`, `@ts-ignore`, skipped tests, and ignored check paths. An unexplained suppression is indistinguishable from a rule nobody needs. Committed `.only` tests are prohibited; remove the focus marker instead of explaining it.
 - Do not perform large rewrites without an explicit request.
 - Prefer minimal diffs that preserve existing behavior outside the requested scope.
 - Preserve public APIs, response shapes, event formats, exported names, and configuration keys unless the task requires changing them.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-07-03'
+  last-reviewed: '2026-07-22'
 ---
 
 # Code Review
@@ -36,6 +36,16 @@ Review code changes and report actionable, evidence-grounded findings before mer
 - [security-reviewer](../../agents/security-reviewer.md): load for security-sensitive diffs or dedicated security review.
 - [backend-architect](../../agents/backend-architect.md): load for backend architecture, service boundary, data flow, or cross-module design review.
 - [tests](../../agents/tests.md): load when test quality, missing coverage, or flaky validation is a major review concern.
+
+## Parallel Specialist Review
+
+Stay single-context for small diffs. Fan out when the diff exceeds roughly 400 changed lines, spans at least three review axes, or one axis needs more depth than the generalist pass will reach.
+
+Use a fast, lower-cost model for bounded read-only evidence collection. Use a higher-capability model for security, architecture, cross-module correctness, and final synthesis. Escalate uncertain high-impact findings to the higher-capability model.
+
+Route security to the [security-reviewer role](../../agents/security-reviewer.md) plus [security-review checklist](../../checklists/security-review.md), tests to the [tests role](../../agents/tests.md) plus [tests checklist](../../checklists/tests.md), and architecture to the [backend-architect role](../../agents/backend-architect.md). Correctness, performance, and intent have no dedicated role; scope correctness and performance with the matching [Correctness](../../checklists/code-review.md#correctness) and [Performance](../../checklists/code-review.md#performance) sections. For intent, use the linked issue or PR description plus the description-matches-diff item in the [PR-readiness checklist](../../checklists/pr-readiness.md).
+
+Use [subagent-orchestration](../subagent-orchestration/SKILL.md) for launch mechanics, parallelism, and the read-only posture. Each specialist returns findings in the [Finding Template](#finding-template) shape; the main session runs passes 3 and 4 over their union, merges shared root causes, drops anchors it cannot re-locate, and emits one ranked list through the existing [Output Format](#output-format). Never post separate specialist outputs.
 
 ## Workflow
 

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-07-22'
+  last-reviewed: '2026-07-23'
 ---
 
 # Debug
@@ -37,16 +37,17 @@ Find a reproducible root cause and, when implementation is requested, apply the 
 
 1. Capture the exact error and failing command.
 2. Run the shortest reproduction path and capture the actual output. If the bug does not reproduce, try other evidence-backed triggering conditions before concluding.
-3. Inspect recent changes and nearby code.
-4. Form 2-3 plausible hypotheses.
-5. Test hypotheses one by one until the root cause, violated invariant, and relevant `file:line` locations are supported by evidence.
-6. Before changing code, state why the planned change closes the violated invariant. If that explanation does not map to the identified root cause, reconsider — the change is probably targeting a symptom.
-7. If implementation is requested, fix the minimal root cause.
-8. When a fix is made, add or update a regression test when practical, in the project's real test suite and matching its existing framework and naming conventions.
-9. When a fix is made, re-run the reproduction against the fixed code and show the actual output. An assertion that it should now pass is not evidence.
-10. When a fix is made, check its side effects: name the behavior near the change that could break (null and empty cases, boundaries, concurrent callers, changed error types, ordering, performance), each with a concrete triggering input and the `file:line` where behavior diverges. If none apply, name the callers and inputs checked and why each is unaffected.
-11. Scan for the same wrong assumption elsewhere in the codebase. Report matches as `file:line` plus a short excerpt and the searches run; report no matches only alongside at least two distinct searches. Do not expand the current fix to cover them — raise them as follow-ups.
-12. Report the root cause and validation.
+3. For a multi-stage or CI failure, read the full job log rather than a single pasted line, and find the **first** failure — later failing steps are usually cascades of it. A lone error line is not enough context to fix from; identify the failing stage and command before forming hypotheses.
+4. Inspect recent changes and nearby code.
+5. Form 2-3 plausible hypotheses.
+6. Test hypotheses one by one until the root cause, violated invariant, and relevant `file:line` locations are supported by evidence.
+7. Before changing code, state why the planned change closes the violated invariant. If that explanation does not map to the identified root cause, reconsider — the change is probably targeting a symptom.
+8. If implementation is requested, fix the minimal root cause.
+9. When a fix is made, add or update a regression test when practical, in the project's real test suite and matching its existing framework and naming conventions.
+10. When a fix is made, re-run the reproduction against the fixed code and show the actual output. An assertion that it should now pass is not evidence.
+11. When a fix is made, check its side effects: name the behavior near the change that could break (null and empty cases, boundaries, concurrent callers, changed error types, ordering, performance), each with a concrete triggering input and the `file:line` where behavior diverges. If none apply, name the callers and inputs checked and why each is unaffected.
+12. Scan for the same wrong assumption elsewhere in the codebase. Report matches as `file:line` plus a short excerpt and the searches run; report no matches only alongside at least two distinct searches. Do not expand the current fix to cover them — raise them as follow-ups.
+13. Report the root cause and validation.
 
 ## Output Format
 

--- a/.agents/skills/refactor/SKILL.md
+++ b/.agents/skills/refactor/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   created: '2026-04-25'
   status: 'baseline'
   portability: 'cross-tool'
-  last-reviewed: '2026-05-05'
+  last-reviewed: '2026-07-22'
 ---
 
 # Refactor
@@ -33,16 +33,21 @@ Improve structure while preserving behavior.
 - [backend-architect](../../agents/backend-architect.md): load for boundary-level refactors, service/repository restructuring, or architectural trade-offs.
 - [tests](../../agents/tests.md): load when behavior-preservation evidence or characterization coverage is unclear.
 
+## Related Workflows
+
+- [plan](../plan/SKILL.md): use when the decomposition is large enough to need a written plan file rather than an inline proposal.
+
 ## Workflow
 
 1. Identify current behavior and public contracts.
 2. Find existing tests or add characterization tests when useful.
 3. Confirm non-goals and behavior that must not change.
-4. Make small mechanical changes.
-5. Preserve public APIs unless explicitly requested.
-6. Avoid mixing refactor with feature work.
-7. Run validation after meaningful steps.
-8. Report before/after structure and behavior-preservation evidence.
+4. For a structural smell — a function or class with accumulated responsibilities, behavior sitting away from its data, or a change that would ripple across unrelated files — state the target decomposition first: responsibilities to extract, modules or methods to create, dependencies to move, and what stays. Get agreement before editing only when the decomposition materially expands scope, changes public contracts, or leaves an ambiguity that prevents a safe choice. Small local extractions do not need this.
+5. Make small mechanical changes.
+6. Preserve public APIs unless explicitly requested.
+7. Avoid mixing refactor with feature work.
+8. Run validation after meaningful steps.
+9. Report before/after structure and behavior-preservation evidence.
 
 ## Output Format
 

--- a/docs/_todo/devops-ci-cd/terraform-iac/README.md
+++ b/docs/_todo/devops-ci-cd/terraform-iac/README.md
@@ -13,6 +13,7 @@
 
 - [ ] Pick CDK for shop-feature-fastify; stand up the stack described in [../../cloud-services/aws/](../../cloud-services/aws/).
 - [ ] Wire CDK deploy into GitHub Actions using OIDC.
+- [ ] Before the first stack lands, decide where the IaC review gate lives — a section here or a checklist in `.agents/checklists/` — and record the choice.
 - [ ] Document the environment strategy (dev / staging / prod account isolation).
 
 ## Concepts to know
@@ -20,6 +21,9 @@
 - Never edit resources in the console if IaC manages them — drift.
 - State file contains secrets; protect access.
 - Small changes beat one-shot rewrites; keep plans readable.
+- AI-generated infrastructure needs a requirements gate before generation — backend, workspace, naming, region, tags, and network are asked for, never guessed. Plausible-looking infrastructure that is wrong for the environment is the common failure.
+- `fmt`, `validate`, and scanners are a mandatory gate but not proof: they check syntax and known patterns, not whether the stack is correct for this environment. High-severity findings block; deferring a low-severity one needs a written reason.
+- `terraform plan` runs only on explicit request. Serialize plans that target the same backend state or workspace to avoid lock contention and confusing output; independent states may plan concurrently when intended.
 - CDK escapes with `CfnResource` when L2 constructs don't support something.
 
 ## Interview questions
@@ -28,3 +32,4 @@
 - How do you handle secrets in Terraform state?
 - Someone hotfixed prod in the console. How do you detect and recover?
 - Blue-green deploys via IaC — how?
+- How would you let an AI assistant write Terraform without losing auditability?

--- a/workspaces/apps/shop-mvc-express/src/infra/shutdown.ts
+++ b/workspaces/apps/shop-mvc-express/src/infra/shutdown.ts
@@ -32,7 +32,7 @@ export function registerGracefulShutdown(
       const message = `Forcing shutdown after ${timeoutMs}ms. Exit 1 (forced-timeout): shutdown exceeded ${timeoutMs}ms (elapsed=${elapsed}ms, signal=${signal}, pid=${pid}, uptime=${process.uptime().toFixed(1)}s)`;
 
       console.warn(gracefulLine(ui.warn(message)));
-      // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit
+      // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit -- Explicit exit codes are required by the shutdown path.
       process.exit(1);
     }, timeoutMs);
 
@@ -58,7 +58,7 @@ export function registerGracefulShutdown(
       console.log(gracefulLine(ui.success(message)));
 
       // Exit cleanly
-      // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit
+      // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit -- Explicit exit codes are required by the shutdown path.
       process.exit(0);
     } catch (error) {
       const elapsed = Date.now() - start;
@@ -67,7 +67,7 @@ export function registerGracefulShutdown(
       console.error(gracefulLine(ui.error(message)));
       console.error(gracefulLine(ui.error('Error details:')), error);
       // Non-zero exit on failure
-      // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit
+      // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit -- Explicit exit codes are required by the shutdown path.
       process.exit(1);
     } finally {
       clearTimeout(hard);

--- a/workspaces/packages/errors/src/index.ts
+++ b/workspaces/packages/errors/src/index.ts
@@ -126,7 +126,7 @@ export interface ValidationErrorDetails {
   }[];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Keep a named public options type for this error while it matches the shared base.
 export interface ValidationErrorOptions extends Omit<
   HttpErrorOptions<ValidationErrorDetails>,
   'statusCode'
@@ -159,7 +159,7 @@ export interface UnauthorizedErrorDetails {
   reason?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Keep a named public options type for this error while it matches the shared base.
 export interface UnauthorizedErrorOptions extends Omit<
   HttpErrorOptions<UnauthorizedErrorDetails>,
   'statusCode'
@@ -193,7 +193,7 @@ export interface ForbiddenErrorDetails {
   reason?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Keep a named public options type for this error while it matches the shared base.
 export interface ForbiddenErrorOptions extends Omit<
   HttpErrorOptions<ForbiddenErrorDetails>,
   'statusCode'
@@ -227,7 +227,7 @@ export interface ConflictErrorDetails {
   constraint?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Keep a named public options type for this error while it matches the shared base.
 export interface ConflictErrorOptions extends Omit<
   HttpErrorOptions<ConflictErrorDetails>,
   'statusCode'
@@ -260,7 +260,7 @@ export interface TooManyRequestsErrorDetails {
   retryAfterSeconds?: number;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Keep a named public options type for this error while it matches the shared base.
 export interface TooManyRequestsErrorOptions extends Omit<
   HttpErrorOptions<TooManyRequestsErrorDetails>,
   'statusCode'


### PR DESCRIPTION
## Summary

Strengthens shared AI-agent guidance for code review, debugging, refactoring, security, and PR readiness. It also adds governed IaC practices and documents the rationale for existing lint suppressions without changing runtime behavior.

## Changes

- **Review quality** — Add specialist-review routing, threat-model guidance, stronger security checks, and clearer PR-readiness expectations.
- **Engineering workflows** — Improve first-failure debugging and require explicit decomposition for larger refactors.
- **Change discipline** — Require justified suppressions and prohibit committed `.only` tests.
- **IaC governance** — Add requirements, validation, review-gate, and state-scoped Terraform planning guidance.
- **Source compliance** — Document why the existing shutdown and public error-type lint suppressions are necessary.